### PR TITLE
🧹 Add mainnet simulation

### DIFF
--- a/.github/workflows/reusable-configure.yaml
+++ b/.github/workflows/reusable-configure.yaml
@@ -17,6 +17,28 @@ env:
   # in .npmrc file and if undefined, the node setup would fail
   NPM_TOKEN: ""
 
+  # We'll add all the RPC URLs from secrets
+  #
+  # Mainnet
+  RPC_URL_ARBITRUM_MAINNET: ${{ secrets.RPC_URL_ARBITRUM_MAINNET }}
+  RPC_URL_AURORA_MAINNET: ${{ secrets.RPC_URL_AURORA_MAINNET }}
+  RPC_URL_AVALANCHE_MAINNET: ${{ secrets.RPC_URL_AVALANCHE_MAINNET }}
+  RPC_URL_BASE_MAINNET: ${{ secrets.RPC_URL_BASE_MAINNET }}
+  RPC_URL_BSC_MAINNET: ${{ secrets.RPC_URL_BSC_MAINNET }}
+  RPC_URL_EBI_MAINNET: ${{ secrets.RPC_URL_EBI_MAINNET }}
+  RPC_URL_ETHEREUM_MAINNET: ${{ secrets.RPC_URL_ETHEREUM_MAINNET }}
+  RPC_URL_KAVA_MAINNET: ${{ secrets.RPC_URL_KAVA_MAINNET }}
+  RPC_URL_KLAYTN_MAINNET: ${{ secrets.RPC_URL_KLAYTN_MAINNET }}
+  RPC_URL_MANTLE_MAINNET: ${{ secrets.RPC_URL_MANTLE_MAINNET }}
+  RPC_URL_METIS_MAINNET: ${{ secrets.RPC_URL_METIS_MAINNET }}
+  RPC_URL_OPTIMISM_MAINNET: ${{ secrets.RPC_URL_OPTIMISM_MAINNET }}
+  RPC_URL_POLYGON_MAINNET: ${{ secrets.RPC_URL_POLYGON_MAINNET }}
+  RPC_URL_SCROLL_MAINNET: ${{ secrets.RPC_URL_SCROLL_MAINNET }}
+  RPC_URL_ZKCONSENSYS_MAINNET: ${{ secrets.RPC_URL_ZKCONSENSYS_MAINNET }}
+  RPC_URL_ZKSYNC_MAINNET: ${{ secrets.RPC_URL_ZKSYNC_MAINNET }}
+  # Testnet
+  RPC_URL_OPTIMISM_TESTNET: ${{ secrets.RPC_URL_OPTIMISM_TESTNET }}
+
 jobs:
   deploy-sandbox:
     name: Deploy and configure sandbox

--- a/.github/workflows/reusable-configure.yaml
+++ b/.github/workflows/reusable-configure.yaml
@@ -75,3 +75,42 @@ jobs:
           LZ_ENABLE_EXPERIMENTAL_BATCHED_WAIT: 1
           # Run under simulation
           LZ_EXPERIMENTAL_WITH_SIMULATION: 1
+
+  deploy-mainnet:
+    name: Deploy and configure mainnet (simulation)
+    runs-on: ubuntu-latest-4xlarge
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Build
+        uses: ./.github/workflows/actions/build
+
+      - name: Start simulation
+        run: pnpm --filter @stargatefinance/stg-evm-v2 run hardhat lz:test:simulation:start --daemon --stage mainnet
+        env:
+          LZ_ENABLE_EXPERIMENTAL_SIMULATION: 1
+
+      - name: Deploy mainnet (simulation)
+        run: make deploy-mainnet DEPLOY_ARGS_COMMON="--ci --reset"
+        env:
+          # Run under simulation
+          LZ_EXPERIMENTAL_WITH_SIMULATION: 1
+
+      - name: Configure mainnet (simulation)
+        run: make configure-mainnet CONFIGURE_ARGS_COMMON=--ci
+        env:
+          LZ_ENABLE_EXPERIMENTAL_PARALLEL_EXECUTION: 1
+          LZ_ENABLE_EXPERIMENTAL_RETRY: 1
+          LZ_ENABLE_EXPERIMENTAL_BATCHED_WAIT: 1
+          # Run under simulation
+          LZ_EXPERIMENTAL_WITH_SIMULATION: 1
+
+      - name: Transfer mainnet ownership (simulation)
+        run: make transfer-mainnet CONFIGURE_ARGS_COMMON=--ci
+        env:
+          LZ_ENABLE_EXPERIMENTAL_PARALLEL_EXECUTION: 1
+          LZ_ENABLE_EXPERIMENTAL_RETRY: 1
+          LZ_ENABLE_EXPERIMENTAL_BATCHED_WAIT: 1
+          # Run under simulation
+          LZ_EXPERIMENTAL_WITH_SIMULATION: 1


### PR DESCRIPTION
### In this PR

- Add a github workflow that deploys, configures & transfers the mainnet contracts under devtools simulation
- This workflow can then be reused to produce a diff of the expected on-chain state