### PR TITLE
🗞️ Bump package versions to 1.0.0

### DIFF
--- a/.changeset/metal-clocks-sneeze.md
+++ b/.changeset/metal-clocks-sneeze.md
@@ -1,0 +1,8 @@
+---
+"@stargatefinance/stg-definitions-v2": major
+"@stargatefinance/stg-error-parser": major
+"@stargatefinance/stg-evm-sdk-v2": major
+"@stargatefinance/stg-evm-v2": major
+---
+
+Version 1.0.0. This version contains no breaking changes and has no implications for downstream projects.

--- a/packages/stg-definitions-v2/package.json
+++ b/packages/stg-definitions-v2/package.json
@@ -1,7 +1,14 @@
 {
   "name": "@stargatefinance/stg-definitions-v2",
   "version": "0.3.23",
-  "private": true,
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs"
+    },
+    "./package.json": "./package.json"
+  },
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -22,7 +29,7 @@
     "tsup": "^8.0.1",
     "typescript": "~5.4.3"
   },
-  "peerDependencies": {
-    "@safe-global/protocol-kit": "^1.3.0"
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/stg-error-parser/package.json
+++ b/packages/stg-error-parser/package.json
@@ -36,6 +36,6 @@
     "typescript": "~5.4.3"
   },
   "publishConfig": {
-    "access": "restricted"
+    "access": "public"
   }
 }

--- a/packages/stg-evm-sdk-v2/package.json
+++ b/packages/stg-evm-sdk-v2/package.json
@@ -53,6 +53,6 @@
     "typescript": "~5.4.3"
   },
   "publishConfig": {
-    "access": "restricted"
+    "access": "public"
   }
 }

--- a/packages/stg-evm-v2/devtools/config/sandbox/mint.allowance.config.ts
+++ b/packages/stg-evm-v2/devtools/config/sandbox/mint.allowance.config.ts
@@ -1,5 +1,4 @@
-import { RewardTokenName } from '@stargatefinance/stg-definitions-v2'
-import { REWARDS } from '@stargatefinance/stg-definitions-v2/src'
+import { REWARDS, RewardTokenName } from '@stargatefinance/stg-definitions-v2'
 
 import { OmniGraphHardhat, createContractFactory, createGetHreByEid } from '@layerzerolabs/devtools-evm-hardhat'
 import { EndpointId } from '@layerzerolabs/lz-definitions'

--- a/packages/stg-evm-v2/devtools/config/testnet/mint.allowance.config.ts
+++ b/packages/stg-evm-v2/devtools/config/testnet/mint.allowance.config.ts
@@ -1,5 +1,4 @@
-import { ASSETS, RewardTokenName, TokenName } from '@stargatefinance/stg-definitions-v2'
-import { REWARDS } from '@stargatefinance/stg-definitions-v2/src'
+import { ASSETS, REWARDS, RewardTokenName, TokenName } from '@stargatefinance/stg-definitions-v2'
 
 import { OmniGraphHardhat, createContractFactory, createGetHreByEid } from '@layerzerolabs/devtools-evm-hardhat'
 import { EndpointId } from '@layerzerolabs/lz-definitions'

--- a/packages/stg-evm-v2/package.json
+++ b/packages/stg-evm-v2/package.json
@@ -132,6 +132,6 @@
     "zod": "~3.22.4"
   },
   "publishConfig": {
-    "access": "restricted"
+    "access": "public"
   }
 }


### PR DESCRIPTION
### In this PR

- Prepare packages for the first major version
- Fix import paths in `mint.allowance.config` that surfaced after the `exports` field has been added to `stg-definitions-v2`
- Bump the versions
- Make packages public