### PR TITLE
🧹 Stargate state snapshot: Collect asset type [6/N]

### DIFF
--- a/packages/stg-evm-v2/devtools/src/asset/types.ts
+++ b/packages/stg-evm-v2/devtools/src/asset/types.ts
@@ -8,7 +8,7 @@ import type {
 } from '@layerzerolabs/devtools'
 import type { EndpointId } from '@layerzerolabs/lz-definitions'
 import type { IOwnable, OwnableNodeConfig } from '@layerzerolabs/ua-devtools'
-import type { AssetId } from '@stargatefinance/stg-definitions-v2'
+import type { AssetId, StargateType } from '@stargatefinance/stg-definitions-v2'
 
 export interface AssetEdgeConfig {
     isOFT?: boolean
@@ -36,6 +36,8 @@ export interface IAsset extends IOmniSDK, IOwnable {
 
     getToken(): Promise<OmniAddress | undefined>
     getLPToken(): Promise<OmniAddress | undefined>
+
+    getStargateType(): Promise<StargateType>
 }
 
 export interface AddressConfig {

--- a/packages/stg-evm-v2/tasks/snapshot.ts
+++ b/packages/stg-evm-v2/tasks/snapshot.ts
@@ -1,5 +1,6 @@
 import { writeFileSync } from 'fs'
 
+import { StargateType } from '@stargatefinance/stg-definitions-v2'
 import { task } from 'hardhat/config'
 
 import { OmniAddress, OmniPoint, formatEid, formatOmniPoint, tapError } from '@layerzerolabs/devtools'
@@ -172,7 +173,8 @@ const createCollectAsset =
         const sdk = await createSdk(point)
 
         logger.verbose(`Collecting basic information`)
-        const [owner, paused, addressConfig, lpTokenAddress, tokenAddress] = await Promise.all([
+        const [type, owner, paused, addressConfig, lpTokenAddress, tokenAddress] = await Promise.all([
+            sdk.getStargateType(),
             sdk.getOwner(),
             sdk.isPaused(),
             sdk.getAddressConfig(),
@@ -207,6 +209,7 @@ const createCollectAsset =
         const snapshot: AssetSnapshot = {
             address: point.address,
             addressConfig,
+            type,
             owner,
             paused,
             lpToken,
@@ -313,6 +316,7 @@ interface CreditMessagingSnapshot extends MessagingSnapshot {
 }
 
 interface AssetSnapshot {
+    type: StargateType
     owner?: OmniAddress
     paused: boolean
     address: OmniAddress


### PR DESCRIPTION
### In this PR

- Add `getStargateType` method to `Asset` SDK
- Collect `StargateType` from the assets when creating the snapshot