### PR TITLE
🧹 Add ./dist to exports to support hardhat consumers

### DIFF
--- a/.changeset/selfish-bulldogs-mix.md
+++ b/.changeset/selfish-bulldogs-mix.md
@@ -1,0 +1,5 @@
+---
+"@stargatefinance/stg-evm-v2": patch
+---
+
+Add ./dist exports to support older consumers

--- a/packages/stg-evm-v2/package.json
+++ b/packages/stg-evm-v2/package.json
@@ -18,6 +18,16 @@
       "import": "./dist/deployed/*.mjs",
       "require": "./dist/deployed/*.cjs"
     },
+    "./dist": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs"
+    },
+    "./dist/*": {
+      "types": "./dist/*.d.ts",
+      "import": "./dist/*.mjs",
+      "require": "./dist/*.cjs"
+    },
     "./package.json": "./package.json"
   },
   "main": "./dist/index.cjs",
@@ -26,7 +36,7 @@
     "dist",
     "artifacts",
     "deployments",
-    "src/**/*"
+    "src"
   ],
   "scripts": {
     "build": "$npm_execpath build:exports && $npm_execpath build:ts",


### PR DESCRIPTION
### In this PR

- In hardhat projects the TypeScript situation is a bit tight - long story short, it is extremely cumbersome to setup `bundler`/`nodenext` TypeScript module resolution. Without this module resolution, it is impossible to use the `exports` field. However, when trying to import from `./dist/` paths, the TypeScript code completion fails. 