### PR TITLE
Fixed broken link in DEPLOYMENT.md

### DIFF
--- a/packages/stg-evm-v2/DEPLOYMENT.md
+++ b/packages/stg-evm-v2/DEPLOYMENT.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="https://stargate.finance">
-    <img src="https://stargate.finance/media/images/og-image.jpg"/>
+    <img src="https://stargate.finance/static/og-image.jpg"/>
   </a>
 </p>
 


### PR DESCRIPTION
Fixed image link in `DEPLOYMENT.md`:

- Updated from `https://stargate.finance/media/images/og-image.jpg` to `https://stargate.finance/static/og-image.jpg`.