### PR TITLE
chore:  document queue_capacity limitation

### DIFF
--- a/packages/stg-evm-v2/src/messaging/TokenMessaging.sol
+++ b/packages/stg-evm-v2/src/messaging/TokenMessaging.sol
@@ -14,6 +14,7 @@ import { AddressCast } from "../libs/AddressCast.sol";
 
 contract TokenMessaging is Transfer, MessagingBase, TokenMessagingOptions, ITokenMessaging {
     /// @dev The maximum number of passengers is queueCapacity - 1 to avoid overwriting the hash root.
+    /// @dev queueCapacity *must* be a divisor of 2e16.
     uint16 public immutable queueCapacity;
     uint32 internal immutable localEid;
 
@@ -33,6 +34,7 @@ contract TokenMessaging is Transfer, MessagingBase, TokenMessagingOptions, IToke
     error Messaging_MaxNumPassengersExceedsQueueCapacity();
     error Messaging_NotEnoughPassengers();
 
+    /// @param _queueCapacity The maximum number of passengers that can be accommodated in the bus queue.  Must be a divisor of 2e16.
     constructor(address _endpoint, address _owner, uint16 _queueCapacity) MessagingBase(_endpoint, _owner) {
         if (_queueCapacity < 2) revert Messaging_InvalidQueueCapacity(); // queue capacity must be at least 2
         queueCapacity = _queueCapacity;


### PR DESCRIPTION
Did not change the contract logic as it would require a subsequent audit to assert.  Instead, just clearly document the limitation.