### PR TITLE
🪲 Add default for ETH RPC URL

### DIFF
--- a/.github/workflows/reusable-gas-snapshot.yaml
+++ b/.github/workflows/reusable-gas-snapshot.yaml
@@ -37,4 +37,4 @@ jobs:
       - name: Snapshot gas
         run: pnpm --filter @stargatefinance/stg-evm-v2 run forge snapshot --snap snapshot.gas
         env:
-          RPC_URL_ETHEREUM_MAINNET: ${{ secrets.RPC_URL_ETHEREUM_MAINNET }}
+          RPC_URL_ETHEREUM_MAINNET: ${{ secrets.RPC_URL_ETHEREUM_MAINNET || 'https://rpc.ankr.com/eth' }}

--- a/.github/workflows/reusable-test.yaml
+++ b/.github/workflows/reusable-test.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Test
         run: pnpm test
         env:
-          RPC_URL_ETHEREUM_MAINNET: ${{ secrets.RPC_URL_ETHEREUM_MAINNET }}
+          RPC_URL_ETHEREUM_MAINNET: ${{ secrets.RPC_URL_ETHEREUM_MAINNET || 'https://rpc.ankr.com/eth' }}
 
   profile-gas:
     name: Profile gas
@@ -55,7 +55,7 @@ jobs:
           cat profile.log | grep -e '\(^|\)\|\(^[[:blank:]]*$\)' >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
         env:
-          RPC_URL_ETHEREUM_MAINNET: ${{ secrets.RPC_URL_ETHEREUM_MAINNET }}
+          RPC_URL_ETHEREUM_MAINNET: ${{ secrets.RPC_URL_ETHEREUM_MAINNET || 'https://rpc.ankr.com/eth' }}
 
       - name: Create summary
         run: |


### PR DESCRIPTION
### In this PR

- Supply a default value for `RPC_URL_ETHEREUM_MAINNET` that's used for fork testing. This fixes PRs from external repos that didn't have access to repository secrets