### PR TITLE
🧵 OFTWrapper deploy script

### DIFF
--- a/.changeset/neat-trainers-travel.md
+++ b/.changeset/neat-trainers-travel.md
@@ -1,0 +1,6 @@
+---
+"@stargatefinance/stg-definitions-v2": patch
+"@stargatefinance/stg-evm-v2": patch
+---
+
+Add OFTWrapper configuration constants & deploy script

--- a/packages/stg-definitions-v2/src/constant.ts
+++ b/packages/stg-definitions-v2/src/constant.ts
@@ -6,6 +6,7 @@ import {
     type AssetConfig,
     CreditMessagingNetworkConfig,
     NetworksConfig,
+    OftWrapperConfig,
     RewardTokenName,
     RewardsConfig,
     StargateType,
@@ -457,6 +458,12 @@ export const ASSETS: Record<TokenName, AssetConfig> = {
             },
         },
     },
+}
+
+export const OFT_WRAPPER: OftWrapperConfig = {
+    bps: 2n,
+    // Any networks defined here will be picked up by the deploy script
+    networks: {},
 }
 
 export const REWARDS: RewardsConfig = {

--- a/packages/stg-definitions-v2/src/types.ts
+++ b/packages/stg-definitions-v2/src/types.ts
@@ -103,3 +103,12 @@ export interface TokenMessagingNetworkConfig {
     requiredDVNs?: string[]
     executor?: string
 }
+
+export interface OftWrapperConfig {
+    bps: bigint
+    networks: Partial<Record<EndpointId, OftWrapperNetworkConfig>>
+}
+
+export interface OftWrapperNetworkConfig {
+    bps?: bigint
+}

--- a/packages/stg-evm-v2/deploy/020-deploy-oft-wrapper.ts
+++ b/packages/stg-evm-v2/deploy/020-deploy-oft-wrapper.ts
@@ -1,0 +1,44 @@
+import 'hardhat-deploy'
+
+import '@nomiclabs/hardhat-ethers'
+
+import { OFT_WRAPPER } from '@stargatefinance/stg-definitions-v2'
+
+import { formatEid } from '@layerzerolabs/devtools'
+import { getEidForNetworkName } from '@layerzerolabs/devtools-evm-hardhat'
+import { createModuleLogger } from '@layerzerolabs/io-devtools'
+
+import { CONTRACT_OFT_WRAPPER_TAGS } from '../ts-src'
+import { createDeploy, getFeeData } from '../ts-src/utils/deployments'
+
+import type { DeployFunction } from 'hardhat-deploy/dist/types'
+
+const deploy: DeployFunction = async (hre) => {
+    const eid = getEidForNetworkName(hre.network.name, hre)
+    const logger = createModuleLogger(`OFTWrapper @ ${formatEid(eid)}`)
+
+    const networkConfig = OFT_WRAPPER.networks[eid]
+    if (networkConfig == null) {
+        return logger.warn(`No config, skipping`), undefined
+    }
+
+    const bps = networkConfig.bps ?? OFT_WRAPPER.bps
+    logger.info(`Setting BPS to ${bps}`)
+
+    const deploy = createDeploy(hre)
+    const feeData = await getFeeData(hre)
+    const { deployer } = await hre.getNamedAccounts()
+
+    await deploy('OFTWrapper', {
+        from: deployer,
+        log: true,
+        args: [bps],
+        waitConfirmations: 1,
+        skipIfAlreadyDeployed: true,
+        ...feeData,
+    })
+}
+
+deploy.tags = CONTRACT_OFT_WRAPPER_TAGS
+
+export default deploy

--- a/packages/stg-evm-v2/ts-src/constants.ts
+++ b/packages/stg-evm-v2/ts-src/constants.ts
@@ -11,6 +11,7 @@ export const CONTRACT_STAKING_TAGS = ['staking']
 export const CONTRACT_STARGATE_TAGS = ['stargate']
 export const CONTRACT_USDC_TAGS = ['usdc']
 export const CONTRACT_USDT_TAGS = ['usdt']
+export const CONTRACT_OFT_WRAPPER_TAGS = ['oft-wrapper']
 
 export const ASSET_TYPE_TOKEN = 0
 export const ASSET_TYPE_LP = 1


### PR DESCRIPTION
### In this PR

- Add `OFT_WRAPPER` configuration constant into `stg-definitions-v2`. This holds the default `bps` value as well as potential network overrides
- Add a deploy script for `OFTWrapper`. This deploy script will skip any networks not defined under `OFT_WRAPPER.networks`