### PR TITLE
🧵 support EndpointV2 OFT in oft-wrapper

### DIFF
--- a/packages/stg-evm-v2/src/peripheral/oft-wrapper/OFTWrapper.sol
+++ b/packages/stg-evm-v2/src/peripheral/oft-wrapper/OFTWrapper.sol
@@ -242,10 +242,10 @@ contract OFTWrapper is IOFTWrapper, Ownable, ReentrancyGuard {
         address _refundAddress,
         FeeObj calldata _feeObj
     ) external payable nonReentrant {
+        /// @dev de-dust and transfer to the wrapper as an intermediate step.
         uint256 decimalConversionRate = epv2_OFT(_oft).decimalConversionRate();
         uint256 amountToSwap = (_getAmountAndPayFee(_oft, _sendParam.amountLD, _sendParam.minAmountLD, _feeObj) /
             decimalConversionRate) * decimalConversionRate;
-        /// @dev Transfer to the wrapper as an intermediate step.
         IERC20(_oft).safeTransferFrom(msg.sender, address(this), amountToSwap);
         epv2_IOFT(_oft).send{ value: msg.value }(
             epv2_SendParam(
@@ -269,11 +269,11 @@ contract OFTWrapper is IOFTWrapper, Ownable, ReentrancyGuard {
         address _refundAddress,
         FeeObj calldata _feeObj
     ) external payable nonReentrant {
+        /// @dev de-dust and transfer to the wrapper as an intermediate step.
         uint256 decimalConversionRate = epv2_OFT(_adapterOFT).decimalConversionRate();
         address token = IOFT(_adapterOFT).token();
         uint256 amountToSwap = (_getAmountAndPayFee(token, _sendParam.amountLD, _sendParam.minAmountLD, _feeObj) /
             decimalConversionRate) * decimalConversionRate;
-        /// @dev Transfer to the wrapper as an intermediate step.
         IERC20(token).safeTransferFrom(msg.sender, address(this), amountToSwap);
         IOFT(token).safeApprove(_adapterOFT, amountToSwap);
         epv2_IOFT(_adapterOFT).send{ value: msg.value }(

--- a/packages/stg-evm-v2/src/peripheral/oft-wrapper/OFTWrapper.sol
+++ b/packages/stg-evm-v2/src/peripheral/oft-wrapper/OFTWrapper.sol
@@ -243,7 +243,6 @@ contract OFTWrapper is IOFTWrapper, Ownable, ReentrancyGuard {
         FeeObj calldata _feeObj
     ) external payable nonReentrant {
         /// @dev de-dust and transfer to the wrapper as an intermediate step.
-        uint256 decimalConversionRate = epv2_OFT(_oft).decimalConversionRate();
         uint256 amountToSwap = _epv2_removeDust(
             _getAmountAndPayFee(_oft, _sendParam.amountLD, _sendParam.minAmountLD, _feeObj),
             _oft

--- a/packages/stg-evm-v2/src/peripheral/oft-wrapper/OFTWrapper.sol
+++ b/packages/stg-evm-v2/src/peripheral/oft-wrapper/OFTWrapper.sol
@@ -11,7 +11,6 @@ import { IOFT } from "@layerzerolabs/solidity-examples/contracts/token/oft/v1/in
 import { IOFTWrapper } from "./interfaces/IOFTWrapper.sol";
 import { INativeOFT } from "./interfaces/INativeOFT.sol";
 import { IOFT as IOFTEpv2, MessagingFee as MessagingFeeEpv2, SendParam as SendParamEpv2 } from "@layerzerolabs/lz-evm-oapp-v2/contracts/oft/interfaces/IOFT.sol";
-import { OFT as OFTEpv2 } from "@layerzerolabs/lz-evm-oapp-v2/contracts/oft/OFT.sol";
 
 contract OFTWrapper is IOFTWrapper, Ownable, ReentrancyGuard {
     using SafeERC20 for IERC20;
@@ -267,7 +266,7 @@ contract OFTWrapper is IOFTWrapper, Ownable, ReentrancyGuard {
     ) external payable nonReentrant {
         address token = IOFT(_adapterOFT).token();
         uint256 amountToSwap = _getAmountAndPayFeeProxy(token, _sendParam.amountLD, _sendParam.minAmountLD, _feeObj);
-        IOFT(token).safeApprove(_adapterOFT, amountToSwap);
+        IERC20(token).safeApprove(_adapterOFT, amountToSwap);
         IOFTEpv2(_adapterOFT).send{ value: msg.value }(
             SendParamEpv2(
                 _sendParam.dstEid,

--- a/packages/stg-evm-v2/src/peripheral/oft-wrapper/OFTWrapper.sol
+++ b/packages/stg-evm-v2/src/peripheral/oft-wrapper/OFTWrapper.sol
@@ -4,14 +4,16 @@ pragma solidity ^0.8.0;
 
 import { ReentrancyGuard } from "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
-import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { IERC20, SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import { IOFTV2 } from "@layerzerolabs/solidity-examples/contracts/token/oft/v2/interfaces/IOFTV2.sol";
 import { IOFTWithFee } from "@layerzerolabs/solidity-examples/contracts/token/oft/v2/fee/IOFTWithFee.sol";
 import { IOFT } from "@layerzerolabs/solidity-examples/contracts/token/oft/v1/interfaces/IOFT.sol";
 import { IOFTWrapper } from "./interfaces/IOFTWrapper.sol";
 import { INativeOFT } from "./interfaces/INativeOFT.sol";
+import { IOFT as epv2_IOFT, MessagingFee as epv2_MessagingFee, SendParam as epv2_SendParam } from "@layerzerolabs/lz-evm-oapp-v2/contracts/oft/interfaces/IOFT.sol";
 
 contract OFTWrapper is IOFTWrapper, Ownable, ReentrancyGuard {
+    using SafeERC20 for IERC20;
     using SafeERC20 for IOFT;
 
     uint256 public constant BPS_DENOMINATOR = 10000;
@@ -232,6 +234,60 @@ contract OFTWrapper is IOFTWrapper, Ownable, ReentrancyGuard {
         );
     }
 
+    function epv2_sendOFT(
+        address _oft,
+        epv2_SendParam calldata _sendParam,
+        epv2_MessagingFee calldata _fee,
+        address _refundAddress,
+        FeeObj calldata _feeObj
+    ) external payable nonReentrant {
+        uint256 amountToSwap = _getAmountAndPayFee(_oft, _sendParam.amountLD, _sendParam.minAmountLD, _feeObj);
+        /// @dev Transfer to the wrapper as an intermediate step.
+        IERC20(_oft).safeTransferFrom(msg.sender, address(this), amountToSwap);
+        epv2_IOFT(_oft).send{ value: msg.value }(
+            epv2_SendParam(
+                _sendParam.dstEid,
+                _sendParam.to,
+                amountToSwap,
+                _sendParam.minAmountLD,
+                _sendParam.extraOptions,
+                _sendParam.composeMsg,
+                _sendParam.oftCmd
+            ),
+            _fee,
+            _refundAddress
+        );
+    }
+
+    function epv2_sendOFTAdapter(
+        address _adapterOFT,
+        epv2_SendParam calldata _sendParam,
+        epv2_MessagingFee calldata _fee,
+        address _refundAddress,
+        FeeObj calldata _feeObj
+    ) external payable nonReentrant {
+        address token = IOFT(_adapterOFT).token();
+        uint256 amountToSwap = _getAmountAndPayFee(token, _sendParam.amountLD, _sendParam.minAmountLD, _feeObj);
+        /// @dev Transfer to the wrapper as an intermediate step.
+        IERC20(token).safeTransferFrom(msg.sender, address(this), amountToSwap);
+        IOFT(token).safeApprove(_adapterOFT, amountToSwap);
+        epv2_IOFT(_adapterOFT).send{ value: msg.value }(
+            epv2_SendParam(
+                _sendParam.dstEid,
+                _sendParam.to,
+                amountToSwap,
+                _sendParam.minAmountLD,
+                _sendParam.extraOptions,
+                _sendParam.composeMsg,
+                _sendParam.oftCmd
+            ),
+            _fee,
+            _refundAddress
+        );
+
+        if (IERC20(token).allowance(address(this), _adapterOFT) > 0) IERC20(token).safeApprove(_adapterOFT, 0);
+    }
+
     function _getAmountAndPayFeeProxy(
         address _token,
         uint256 _amount,
@@ -344,5 +400,28 @@ contract OFTWrapper is IOFTWrapper, Ownable, ReentrancyGuard {
         (uint256 amount, , ) = getAmountAndFees(_oft, _amount, _feeObj.callerBps);
 
         return IOFTV2(_oft).estimateSendFee(_dstChainId, _toAddress, amount, _useZro, _adapterParams);
+    }
+
+    function epv2_estimateSendFee(
+        address _oft,
+        epv2_SendParam calldata _sendParam,
+        bool _payInLzToken,
+        FeeObj calldata _feeObj
+    ) external view returns (epv2_MessagingFee memory) {
+        (uint256 amount, , ) = getAmountAndFees(_oft, _sendParam.amountLD, _feeObj.callerBps);
+
+        return
+            epv2_IOFT(_oft).quoteSend(
+                epv2_SendParam(
+                    _sendParam.dstEid,
+                    _sendParam.to,
+                    amount,
+                    _sendParam.minAmountLD,
+                    _sendParam.extraOptions,
+                    _sendParam.composeMsg,
+                    _sendParam.oftCmd
+                ),
+                _payInLzToken
+            );
     }
 }

--- a/packages/stg-evm-v2/src/peripheral/oft-wrapper/interfaces/IOFTWrapper.sol
+++ b/packages/stg-evm-v2/src/peripheral/oft-wrapper/interfaces/IOFTWrapper.sol
@@ -3,6 +3,7 @@
 pragma solidity ^0.8.0;
 
 import { IOFTV2 } from "@layerzerolabs/solidity-examples/contracts/token/oft/v2/interfaces/IOFTV2.sol";
+import { MessagingFee as epv2_MessagingFee, SendParam as epv2_SendParam } from "@layerzerolabs/lz-evm-oapp-v2/contracts/oft/interfaces/IOFT.sol";
 
 interface IOFTWrapper {
     event DefaultBpsSet(uint256 bps);
@@ -102,6 +103,14 @@ interface IOFTWrapper {
         FeeObj calldata _feeObj
     ) external payable;
 
+    function epv2_sendOFTAdapter(
+        address _adapterOFT,
+        epv2_SendParam calldata _sendParam,
+        epv2_MessagingFee calldata _fee,
+        address _refundAddress,
+        FeeObj calldata _feeObj
+    ) external payable;
+
     function getAmountAndFees(
         address _oft,
         uint256 _amount,
@@ -127,4 +136,11 @@ interface IOFTWrapper {
         bytes calldata _adapterParams,
         FeeObj calldata _feeObj
     ) external view returns (uint nativeFee, uint zroFee);
+
+    function epv2_estimateSendFee(
+        address _oft,
+        epv2_SendParam calldata _sendParam,
+        bool _payInLzToken,
+        FeeObj calldata _feeObj
+    ) external view returns (epv2_MessagingFee memory);
 }

--- a/packages/stg-evm-v2/src/peripheral/oft-wrapper/interfaces/IOFTWrapper.sol
+++ b/packages/stg-evm-v2/src/peripheral/oft-wrapper/interfaces/IOFTWrapper.sol
@@ -3,7 +3,7 @@
 pragma solidity ^0.8.0;
 
 import { IOFTV2 } from "@layerzerolabs/solidity-examples/contracts/token/oft/v2/interfaces/IOFTV2.sol";
-import { MessagingFee as epv2_MessagingFee, SendParam as epv2_SendParam } from "@layerzerolabs/lz-evm-oapp-v2/contracts/oft/interfaces/IOFT.sol";
+import { MessagingFee as MessagingFeeEpv2, SendParam as SendParamEpv2 } from "@layerzerolabs/lz-evm-oapp-v2/contracts/oft/interfaces/IOFT.sol";
 
 interface IOFTWrapper {
     event DefaultBpsSet(uint256 bps);
@@ -103,10 +103,18 @@ interface IOFTWrapper {
         FeeObj calldata _feeObj
     ) external payable;
 
-    function epv2_sendOFTAdapter(
+    function sendOFTEpv2(
+        address _oft,
+        SendParamEpv2 calldata _sendParam,
+        MessagingFeeEpv2 calldata _fee,
+        address _refundAddress,
+        FeeObj calldata _feeObj
+    ) external payable;
+
+    function sendOFTAdapterEpv2(
         address _adapterOFT,
-        epv2_SendParam calldata _sendParam,
-        epv2_MessagingFee calldata _fee,
+        SendParamEpv2 calldata _sendParam,
+        MessagingFeeEpv2 calldata _fee,
         address _refundAddress,
         FeeObj calldata _feeObj
     ) external payable;
@@ -137,10 +145,10 @@ interface IOFTWrapper {
         FeeObj calldata _feeObj
     ) external view returns (uint nativeFee, uint zroFee);
 
-    function epv2_estimateSendFee(
+    function estimateSendFeeEpv2(
         address _oft,
-        epv2_SendParam calldata _sendParam,
+        SendParamEpv2 calldata _sendParam,
         bool _payInLzToken,
         FeeObj calldata _feeObj
-    ) external view returns (epv2_MessagingFee memory);
+    ) external view returns (MessagingFeeEpv2 memory);
 }

--- a/packages/stg-evm-v2/test/unitest/peripheral/oft-wrapper/mocks/ERC20Mock.sol
+++ b/packages/stg-evm-v2/test/unitest/peripheral/oft-wrapper/mocks/ERC20Mock.sol
@@ -1,0 +1,13 @@
+// SPDX-LICENSE-IDENTIFIER: UNLICENSED
+
+pragma solidity ^0.8.0;
+
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract ERC20Mock is ERC20 {
+    constructor(string memory name, string memory symbol) ERC20(name, symbol) {}
+
+    function mint(address account, uint256 amount) public {
+        _mint(account, amount);
+    }
+}

--- a/packages/stg-evm-v2/test/unitest/peripheral/oft-wrapper/mocks/epv2/MockOFT.sol
+++ b/packages/stg-evm-v2/test/unitest/peripheral/oft-wrapper/mocks/epv2/MockOFT.sol
@@ -1,0 +1,27 @@
+// SPDX-LICENSE-Identifier: UNLICENSED
+
+pragma solidity ^0.8.22;
+
+import { OFT as epv2_OFT } from "@layerzerolabs/lz-evm-oapp-v2/contracts/oft/OFT.sol";
+import { OFTAdapter as epv2_OFTAdapter } from "@layerzerolabs/lz-evm-oapp-v2/contracts/oft/OFTAdapter.sol";
+
+contract MockOFT is epv2_OFT {
+    constructor(
+        string memory _name,
+        string memory _symbol,
+        address _lzEndpoint,
+        address _delegate
+    ) epv2_OFT(_name, _symbol, _lzEndpoint, _delegate) {}
+
+    function mint(address _to, uint256 _amount) public {
+        _mint(_to, _amount);
+    }
+}
+
+contract MockOFTAdapter is epv2_OFTAdapter {
+    constructor(
+        address _token,
+        address _lzEndpoint,
+        address _delegate
+    ) epv2_OFTAdapter(_token, _lzEndpoint, _delegate) {}
+}


### PR DESCRIPTION
- Adds an EnpointV2 specific OFTWrapper API.
- Adds a cross-chain test which effectively transfers tokens from A_EID to B_EID, checking accumulated fees along the way.