### PR TITLE
🪲 Skip Treasurer deployments for networks with no TokenMessaging

### DIFF
--- a/packages/stg-evm-v2/deploy/009-deploy-treasurer.ts
+++ b/packages/stg-evm-v2/deploy/009-deploy-treasurer.ts
@@ -2,6 +2,8 @@ import 'hardhat-deploy'
 
 import '@nomiclabs/hardhat-ethers'
 
+import { createModuleLogger } from '@layerzerolabs/io-devtools'
+
 import { CONTRACT_TREASURER_TAGS } from '../ts-src'
 import { createDeploy, getFeeData } from '../ts-src/utils/deployments'
 
@@ -11,6 +13,13 @@ const deploy: DeployFunction = async (hre) => {
     const deploy = createDeploy(hre)
     const feeData = await getFeeData(hre)
     const { deployer } = await hre.getNamedAccounts()
+
+    const logger = createModuleLogger(`Treasurer Deployer @ ${hre.network.name}`)
+
+    const tokenMessaging = await hre.deployments.getOrNull('TokenMessaging')
+    if (tokenMessaging == null) {
+        return logger.warn('Skipping deployment: no TokenMessaging found'), undefined
+    }
 
     await deploy('Treasurer', {
         from: deployer,


### PR DESCRIPTION
### In this PR

- Skip `Treasurer` deployments if there is no `TokenMessaging` present. This is important if we are to add new networks with only `OFTWrapper` on them