### PR TITLE
🪲 estimateSendFee{,v2,Epv2}(...) do not take into account OFT-specific bps

### DIFF
--- a/packages/stg-evm-v2/src/peripheral/oft-wrapper/OFTWrapper.sol
+++ b/packages/stg-evm-v2/src/peripheral/oft-wrapper/OFTWrapper.sol
@@ -2,8 +2,6 @@
 
 pragma solidity ^0.8.0;
 
-import { console } from "forge-std/Console.sol";
-
 import { ReentrancyGuard } from "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 import { IERC20, SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
@@ -357,8 +355,6 @@ contract OFTWrapper is IOFTWrapper, Ownable, ReentrancyGuard {
     ) public view override returns (uint256 amount, uint256 wrapperFee, uint256 callerFee) {
         uint256 wrapperBps;
 
-        console.log("token", _token);
-        console.log("oftBps[_token]", oftBps[_token]);
         if (oftBps[_token] == MAX_UINT) {
             wrapperBps = 0;
         } else if (oftBps[_token] > 0) {
@@ -366,8 +362,6 @@ contract OFTWrapper is IOFTWrapper, Ownable, ReentrancyGuard {
         } else {
             wrapperBps = defaultBps;
         }
-
-        console.log("wrapperBps", wrapperBps);
 
         require(wrapperBps + _callerBps < BPS_DENOMINATOR, "OFTWrapper: Fee bps >= 100%");
 

--- a/packages/stg-evm-v2/src/peripheral/oft-wrapper/OFTWrapper.sol
+++ b/packages/stg-evm-v2/src/peripheral/oft-wrapper/OFTWrapper.sol
@@ -2,6 +2,8 @@
 
 pragma solidity ^0.8.0;
 
+import { console } from "forge-std/Console.sol";
+
 import { ReentrancyGuard } from "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 import { IERC20, SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
@@ -355,6 +357,8 @@ contract OFTWrapper is IOFTWrapper, Ownable, ReentrancyGuard {
     ) public view override returns (uint256 amount, uint256 wrapperFee, uint256 callerFee) {
         uint256 wrapperBps;
 
+        console.log("token", _token);
+        console.log("oftBps[_token]", oftBps[_token]);
         if (oftBps[_token] == MAX_UINT) {
             wrapperBps = 0;
         } else if (oftBps[_token] > 0) {
@@ -362,6 +366,8 @@ contract OFTWrapper is IOFTWrapper, Ownable, ReentrancyGuard {
         } else {
             wrapperBps = defaultBps;
         }
+
+        console.log("wrapperBps", wrapperBps);
 
         require(wrapperBps + _callerBps < BPS_DENOMINATOR, "OFTWrapper: Fee bps >= 100%");
 
@@ -400,11 +406,12 @@ contract OFTWrapper is IOFTWrapper, Ownable, ReentrancyGuard {
 
     function estimateSendFeeEpv2(
         address _oft,
+        address _token,
         SendParamEpv2 calldata _sendParam,
         bool _payInLzToken,
         FeeObj calldata _feeObj
     ) external view returns (MessagingFeeEpv2 memory) {
-        (uint256 amount, , ) = getAmountAndFees(_oft, _sendParam.amountLD, _feeObj.callerBps);
+        (uint256 amount, , ) = getAmountAndFees(_token, _sendParam.amountLD, _feeObj.callerBps);
         return
             IOFTEpv2(_oft).quoteSend(
                 SendParamEpv2(

--- a/packages/stg-evm-v2/src/peripheral/oft-wrapper/OFTWrapper.sol
+++ b/packages/stg-evm-v2/src/peripheral/oft-wrapper/OFTWrapper.sol
@@ -379,7 +379,7 @@ contract OFTWrapper is IOFTWrapper, Ownable, ReentrancyGuard {
         bytes calldata _adapterParams,
         FeeObj calldata _feeObj
     ) external view override returns (uint nativeFee, uint zroFee) {
-        (uint256 amount, , ) = getAmountAndFees(_oft, _amount, _feeObj.callerBps);
+        (uint256 amount, , ) = getAmountAndFees(IOFT(_oft).token(), _amount, _feeObj.callerBps);
 
         return IOFT(_oft).estimateSendFee(_dstChainId, _toAddress, amount, _useZro, _adapterParams);
     }
@@ -393,7 +393,7 @@ contract OFTWrapper is IOFTWrapper, Ownable, ReentrancyGuard {
         bytes calldata _adapterParams,
         FeeObj calldata _feeObj
     ) external view override returns (uint nativeFee, uint zroFee) {
-        (uint256 amount, , ) = getAmountAndFees(_oft, _amount, _feeObj.callerBps);
+        (uint256 amount, , ) = getAmountAndFees(IOFTV2(_oft).token(), _amount, _feeObj.callerBps);
 
         return IOFTV2(_oft).estimateSendFee(_dstChainId, _toAddress, amount, _useZro, _adapterParams);
     }

--- a/packages/stg-evm-v2/src/peripheral/oft-wrapper/OFTWrapper.sol
+++ b/packages/stg-evm-v2/src/peripheral/oft-wrapper/OFTWrapper.sol
@@ -400,12 +400,11 @@ contract OFTWrapper is IOFTWrapper, Ownable, ReentrancyGuard {
 
     function estimateSendFeeEpv2(
         address _oft,
-        address _token,
         SendParamEpv2 calldata _sendParam,
         bool _payInLzToken,
         FeeObj calldata _feeObj
     ) external view returns (MessagingFeeEpv2 memory) {
-        (uint256 amount, , ) = getAmountAndFees(_token, _sendParam.amountLD, _feeObj.callerBps);
+        (uint256 amount, , ) = getAmountAndFees(IOFTEpv2(_oft).token(), _sendParam.amountLD, _feeObj.callerBps);
         return
             IOFTEpv2(_oft).quoteSend(
                 SendParamEpv2(

--- a/packages/stg-evm-v2/src/peripheral/oft-wrapper/interfaces/IOFTWrapper.sol
+++ b/packages/stg-evm-v2/src/peripheral/oft-wrapper/interfaces/IOFTWrapper.sol
@@ -147,7 +147,6 @@ interface IOFTWrapper {
 
     function estimateSendFeeEpv2(
         address _oft,
-        address _token,
         SendParamEpv2 calldata _sendParam,
         bool _payInLzToken,
         FeeObj calldata _feeObj

--- a/packages/stg-evm-v2/src/peripheral/oft-wrapper/interfaces/IOFTWrapper.sol
+++ b/packages/stg-evm-v2/src/peripheral/oft-wrapper/interfaces/IOFTWrapper.sol
@@ -147,6 +147,7 @@ interface IOFTWrapper {
 
     function estimateSendFeeEpv2(
         address _oft,
+        address _token,
         SendParamEpv2 calldata _sendParam,
         bool _payInLzToken,
         FeeObj calldata _feeObj

--- a/packages/stg-evm-v2/test/unitest/peripheral/oft-wrapper/OFTWrapper.t.sol
+++ b/packages/stg-evm-v2/test/unitest/peripheral/oft-wrapper/OFTWrapper.t.sol
@@ -128,13 +128,7 @@ contract OFTWrapperTest is Test, LzTestHelper {
         );
         IOFTWrapper.FeeObj memory feeObj = _createFeeObj(_callerBps, caller, bytes2(0x0034));
 
-        MessagingFeeEpv2 memory fee = oftWrapper.estimateSendFeeEpv2(
-            address(adapter),
-            address(token),
-            sendParam,
-            false,
-            feeObj
-        );
+        MessagingFeeEpv2 memory fee = oftWrapper.estimateSendFeeEpv2(address(adapter), sendParam, false, feeObj);
 
         // 4. Send the tokens from sender on A_EID to receiver on B_EID.
         vm.startPrank(sender);
@@ -174,7 +168,7 @@ contract OFTWrapperTest is Test, LzTestHelper {
             "",
             ""
         );
-        fee = oftWrapper.estimateSendFeeEpv2(address(oft), address(oft), sendParam, false, feeObj);
+        fee = oftWrapper.estimateSendFeeEpv2(address(oft), sendParam, false, feeObj);
         vm.deal(receiver, 1 ether);
 
         uint256 receiverBalance = IERC20(oft).balanceOf(receiver);
@@ -256,13 +250,7 @@ contract OFTWrapperTest is Test, LzTestHelper {
         );
 
         // 4. Estimate the fee.  This should be the same as amount from getAmountAndFees(...)
-        MessagingFeeEpv2 memory fee = oftWrapper.estimateSendFeeEpv2(
-            address(customAdapter),
-            address(token),
-            sendParam,
-            false,
-            feeObj
-        );
+        MessagingFeeEpv2 memory fee = oftWrapper.estimateSendFeeEpv2(address(customAdapter), sendParam, false, feeObj);
 
         // 5. Assert that the fee is as expected.
         (uint256 expectedAmount, , ) = oftWrapper.getAmountAndFees(address(token), _amountLD, _callerBps);
@@ -313,13 +301,7 @@ contract OFTWrapperTest is Test, LzTestHelper {
         );
 
         // 4. Estimate the fee.  This should be the same as amount from getAmountAndFees(...)
-        MessagingFeeEpv2 memory fee = oftWrapper.estimateSendFeeEpv2(
-            address(customOFT),
-            address(customOFT),
-            sendParam,
-            false,
-            feeObj
-        );
+        MessagingFeeEpv2 memory fee = oftWrapper.estimateSendFeeEpv2(address(customOFT), sendParam, false, feeObj);
 
         // 5. Assert that the fee is as expected.
         (uint256 expectedAmount, , ) = oftWrapper.getAmountAndFees(address(customOFT), _amountLD, _callerBps);

--- a/packages/stg-evm-v2/test/unitest/peripheral/oft-wrapper/mocks/epv2/MockOFT.sol
+++ b/packages/stg-evm-v2/test/unitest/peripheral/oft-wrapper/mocks/epv2/MockOFT.sol
@@ -2,26 +2,60 @@
 
 pragma solidity ^0.8.22;
 
-import { OFT as epv2_OFT } from "@layerzerolabs/lz-evm-oapp-v2/contracts/oft/OFT.sol";
-import { OFTAdapter as epv2_OFTAdapter } from "@layerzerolabs/lz-evm-oapp-v2/contracts/oft/OFTAdapter.sol";
+import { MessagingFee as MessagingFeeEpv2, SendParam as SendParamEpv2 } from "@layerzerolabs/lz-evm-oapp-v2/contracts/oft/interfaces/IOFT.sol";
+import { OFT as OFTEpv2 } from "@layerzerolabs/lz-evm-oapp-v2/contracts/oft/OFT.sol";
+import { OFTAdapter as OFTAdapterEpv2 } from "@layerzerolabs/lz-evm-oapp-v2/contracts/oft/OFTAdapter.sol";
 
-contract MockOFT is epv2_OFT {
+contract MockOFT is OFTEpv2 {
     constructor(
         string memory _name,
         string memory _symbol,
         address _lzEndpoint,
         address _delegate
-    ) epv2_OFT(_name, _symbol, _lzEndpoint, _delegate) {}
+    ) OFTEpv2(_name, _symbol, _lzEndpoint, _delegate) {}
 
     function mint(address _to, uint256 _amount) public {
         _mint(_to, _amount);
     }
 }
 
-contract MockOFTAdapter is epv2_OFTAdapter {
+contract CustomQuoteSendMockOFT is MockOFT {
+    constructor(
+        string memory _name,
+        string memory _symbol,
+        address _lzEndpoint,
+        address _delegate
+    ) MockOFT(_name, _symbol, _lzEndpoint, _delegate) {}
+
+    /// @dev A contrived quoteSend function that returns amount as the native fee.
+    function quoteSend(
+        SendParamEpv2 calldata _sendParam,
+        bool /*_payInLzToken*/
+    ) external pure override returns (MessagingFeeEpv2 memory msgFee) {
+        return MessagingFeeEpv2(_sendParam.amountLD, 0);
+    }
+}
+
+contract MockOFTAdapter is OFTAdapterEpv2 {
     constructor(
         address _token,
         address _lzEndpoint,
         address _delegate
-    ) epv2_OFTAdapter(_token, _lzEndpoint, _delegate) {}
+    ) OFTAdapterEpv2(_token, _lzEndpoint, _delegate) {}
+}
+
+contract CustomQuoteSendMockOFTAdapter is MockOFTAdapter {
+    constructor(
+        address _token,
+        address _lzEndpoint,
+        address _delegate
+    ) MockOFTAdapter(_token, _lzEndpoint, _delegate) {}
+
+    /// @dev A contrived quoteSend function that returns amount as the native fee.
+    function quoteSend(
+        SendParamEpv2 calldata _sendParam,
+        bool /*_payInLzToken*/
+    ) external pure override returns (MessagingFeeEpv2 memory msgFee) {
+        return MessagingFeeEpv2(_sendParam.amountLD, 0);
+    }
 }

--- a/packages/stg-evm-v2/test/unitest/peripheral/oft-wrapper/mocks/oft/OFTMock.sol
+++ b/packages/stg-evm-v2/test/unitest/peripheral/oft-wrapper/mocks/oft/OFTMock.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import { OFT as OFTv1 } from "@layerzerolabs/solidity-examples/contracts/token/oft/v1/OFT.sol";
+import { IOFTCore } from "@layerzerolabs/solidity-examples/contracts/token/oft/v1/interfaces/IOFTCore.sol";
+import { OFTCore } from "@layerzerolabs/solidity-examples/contracts/token/oft/v1/OFTCore.sol";
+
+contract OFTMock is OFTv1 {
+    constructor(string memory _name, string memory _symbol, address _lzEndpoint) OFTv1(_name, _symbol, _lzEndpoint) {}
+
+    function estimateSendFee(
+        uint16 /*_dstChainId*/,
+        bytes calldata /*_toAddress*/,
+        uint _amount,
+        bool /*_useZro*/,
+        bytes calldata /*_adapterParams*/
+    ) public pure override(OFTCore, IOFTCore) returns (uint nativeFee, uint zroFee) {
+        nativeFee = _amount;
+        zroFee = 0;
+    }
+}

--- a/packages/stg-evm-v2/test/unitest/peripheral/oft-wrapper/mocks/oft/OFTProxyMock.sol
+++ b/packages/stg-evm-v2/test/unitest/peripheral/oft-wrapper/mocks/oft/OFTProxyMock.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import { ProxyOFT } from "@layerzerolabs/solidity-examples/contracts/token/oft/v1/ProxyOFT.sol";
+
+contract OFTProxyMock is ProxyOFT {
+    constructor(address _lzEndpoint, address _token) ProxyOFT(_lzEndpoint, _token) {}
+
+    function estimateSendFee(
+        uint16 /*_dstChainId*/,
+        bytes calldata /*_toAddress*/,
+        uint _amount,
+        bool /*_useZro*/,
+        bytes calldata /*_adapterParams*/
+    ) public pure override returns (uint nativeFee, uint zroFee) {
+        nativeFee = _amount;
+        zroFee = 0;
+    }
+}

--- a/packages/stg-evm-v2/test/unitest/peripheral/oft-wrapper/mocks/oftv2/OFTMock.sol
+++ b/packages/stg-evm-v2/test/unitest/peripheral/oft-wrapper/mocks/oftv2/OFTMock.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import { OFTV2 } from "@layerzerolabs/solidity-examples/contracts/token/oft/v2/OFTV2.sol";
+
+contract OFTMock is OFTV2 {
+    constructor(
+        string memory _name,
+        string memory _symbol,
+        uint8 _sharedDecimals,
+        address _lzEndpoint
+    ) OFTV2(_name, _symbol, _sharedDecimals, _lzEndpoint) {}
+
+    function estimateSendFee(
+        uint16 /*_dstChainId*/,
+        bytes32 /*_toAddress*/,
+        uint _amount,
+        bool /*_useZro*/,
+        bytes calldata /*_adapterParams*/
+    ) public pure override returns (uint nativeFee, uint zroFee) {
+        nativeFee = _amount;
+        zroFee = 0;
+    }
+}

--- a/packages/stg-evm-v2/test/unitest/peripheral/oft-wrapper/mocks/oftv2/OFTProxyMock.sol
+++ b/packages/stg-evm-v2/test/unitest/peripheral/oft-wrapper/mocks/oftv2/OFTProxyMock.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import { ProxyOFTV2 } from "@layerzerolabs/solidity-examples/contracts/token/oft/v2/ProxyOFTV2.sol";
+
+contract OFTProxyMock is ProxyOFTV2 {
+    constructor(
+        address _token,
+        uint8 _sharedDecimals,
+        address _lzEndpoint
+    ) ProxyOFTV2(_token, _sharedDecimals, _lzEndpoint) {}
+
+    function estimateSendFee(
+        uint16 /*_dstChainId*/,
+        bytes32 /*_toAddress*/,
+        uint _amount,
+        bool /*_useZro*/,
+        bytes calldata /*_adapterParams*/
+    ) public pure override returns (uint nativeFee, uint zroFee) {
+        nativeFee = _amount;
+        zroFee = 0;
+    }
+}


### PR DESCRIPTION
This is actually broken in the following three functions:
* estimateSendFee(...)
* estimateSendFeeV2(...)
* estimateSendFeeEpv2(...)

The latter two functions are released and deployed, so we must protect the interface.  It doesn't actually end up making a difference as the messaging fee is the same regardless of the bps configuration in the default implementation.  That said, it is not future proof for Adapter implementations in which the MessagingFee may vary based on the configured bps.

This PR fixes the implementation of all three.