### PR TITLE
🪲 assert a cap for caller bps

### DIFF
--- a/packages/stg-definitions-v2/src/constant.ts
+++ b/packages/stg-definitions-v2/src/constant.ts
@@ -462,6 +462,7 @@ export const ASSETS: Record<TokenName, AssetConfig> = {
 
 export const OFT_WRAPPER: OftWrapperConfig = {
     bps: 2n,
+    callerBpsCap: 300n,
     // Any networks defined here will be picked up by the deploy script
     networks: {
         //

--- a/packages/stg-definitions-v2/src/types.ts
+++ b/packages/stg-definitions-v2/src/types.ts
@@ -112,4 +112,5 @@ export interface OftWrapperConfig {
 
 export interface OftWrapperNetworkConfig {
     bps?: bigint
+    callerBpsCap?: bigint
 }

--- a/packages/stg-definitions-v2/src/types.ts
+++ b/packages/stg-definitions-v2/src/types.ts
@@ -106,6 +106,7 @@ export interface TokenMessagingNetworkConfig {
 
 export interface OftWrapperConfig {
     bps: bigint
+    callerBpsCap: bigint
     networks: Partial<Record<EndpointId, OftWrapperNetworkConfig>>
 }
 

--- a/packages/stg-evm-v2/deploy/020-deploy-oft-wrapper.ts
+++ b/packages/stg-evm-v2/deploy/020-deploy-oft-wrapper.ts
@@ -23,7 +23,8 @@ const deploy: DeployFunction = async (hre) => {
     }
 
     const bps = networkConfig.bps ?? OFT_WRAPPER.bps
-    logger.info(`Setting BPS to ${bps}`)
+    const callerBpsCap = networkConfig.callerBpsCap ?? OFT_WRAPPER.callerBpsCap
+    logger.info(`Setting BPS to ${bps} and callerBpsCap to ${callerBpsCap}`)
 
     const deploy = createDeploy(hre)
     const feeData = await getFeeData(hre)
@@ -32,7 +33,7 @@ const deploy: DeployFunction = async (hre) => {
     await deploy('OFTWrapper', {
         from: deployer,
         log: true,
-        args: [bps],
+        args: [bps, callerBpsCap],
         waitConfirmations: 1,
         skipIfAlreadyDeployed: true,
         ...feeData,

--- a/packages/stg-evm-v2/src/peripheral/oft-wrapper/OFTWrapper.sol
+++ b/packages/stg-evm-v2/src/peripheral/oft-wrapper/OFTWrapper.sol
@@ -23,10 +23,10 @@ contract OFTWrapper is IOFTWrapper, Ownable, ReentrancyGuard {
     mapping(address => uint256) public oftBps;
     uint256 public callerBpsCap;
 
-    constructor(uint256 _defaultBps) {
+    constructor(uint256 _defaultBps, uint256 _callerBpsCap) {
         require(_defaultBps < BPS_DENOMINATOR, "OFTWrapper: defaultBps >= 100%");
         defaultBps = _defaultBps;
-        callerBpsCap = MAX_UINT; /// @dev unset by default
+        callerBpsCap = _callerBpsCap;
     }
 
     function setDefaultBps(uint256 _defaultBps) external onlyOwner {

--- a/packages/stg-evm-v2/src/peripheral/oft-wrapper/interfaces/IOFTWrapper.sol
+++ b/packages/stg-evm-v2/src/peripheral/oft-wrapper/interfaces/IOFTWrapper.sol
@@ -6,6 +6,7 @@ import { IOFTV2 } from "@layerzerolabs/solidity-examples/contracts/token/oft/v2/
 import { MessagingFee as MessagingFeeEpv2, SendParam as SendParamEpv2 } from "@layerzerolabs/lz-evm-oapp-v2/contracts/oft/interfaces/IOFT.sol";
 
 interface IOFTWrapper {
+    event CallerBpsCapSet(uint256 bps);
     event DefaultBpsSet(uint256 bps);
     event OFTBpsSet(address indexed token, uint256 bps);
     event WrapperFees(bytes2 indexed partnerId, address token, uint256 wrapperFee, uint256 callerFee);

--- a/packages/stg-evm-v2/test/unitest/peripheral/oft-wrapper/OFTWrapper.t.sol
+++ b/packages/stg-evm-v2/test/unitest/peripheral/oft-wrapper/OFTWrapper.t.sol
@@ -6,6 +6,8 @@ import { console, Test } from "@layerzerolabs/toolbox-foundry/lib/forge-std/Test
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
+import { ICommonOFT } from "@layerzerolabs/solidity-examples/contracts/token/oft/v2/interfaces/ICommonOFT.sol";
+
 import { OptionsBuilder } from "@layerzerolabs/lz-evm-oapp-v2/contracts/oapp/libs/OptionsBuilder.sol";
 import { IOFT as IOFTEpv2, MessagingFee as MessagingFeeEpv2, SendParam as SendParamEpv2 } from "@layerzerolabs/lz-evm-oapp-v2/contracts/oft/interfaces/IOFT.sol";
 
@@ -25,7 +27,9 @@ import { OFTMock as OFTv1Mock } from "./mocks/oft/OFTMock.sol";
 contract OFTWrapperTest is Test, LzTestHelper {
     using OptionsBuilder for bytes;
 
-    bytes internal constant INCORRECT_BPS_ERROR = "OFTWrapper: defaultBps >= 100%";
+    bytes internal constant EXCESSIVE_DEFAULT_BPS_CONFIG_ERROR = "OFTWrapper: defaultBps >= 100%";
+    bytes internal constant EXCESSIVE_CALLER_BPS_CONFIG_ERROR = "OFTWrapper: callerBpsCap >= 100%";
+    bytes internal constant EXCESSIVE_CALLER_BPS_ERROR = "OFTWrapper: callerBps > callerBpsCap";
 
     string internal ERC20_MOCK_NAME = "ERC20Mock";
     string internal ERC20_MOCK_SYMBOL = "ERC";
@@ -90,7 +94,7 @@ contract OFTWrapperTest is Test, LzTestHelper {
 
     function test_constructor(uint16 _defaultBps) public {
         if (_defaultBps >= 10000) {
-            vm.expectRevert(INCORRECT_BPS_ERROR);
+            vm.expectRevert(EXCESSIVE_DEFAULT_BPS_CONFIG_ERROR);
             new OFTWrapper(_defaultBps);
         } else {
             OFTWrapper wrapper = new OFTWrapper(_defaultBps);
@@ -455,5 +459,317 @@ contract OFTWrapperTest is Test, LzTestHelper {
         (uint256 expectedAmount, , ) = oftWrapper.getAmountAndFees(address(customOFT), _amountLD, _callerBps);
         assertEq(expectedAmount, fee.nativeFee); /// @dev in this example, nativeFee is manipulated to be amount
         assertEq(0, fee.lzTokenFee);
+    }
+
+    function test_setCallerBpsCap(uint256 _callerBpsCap) public {
+        if (_callerBpsCap >= 10_000 && _callerBpsCap != type(uint256).max) {
+            vm.expectRevert(EXCESSIVE_CALLER_BPS_CONFIG_ERROR);
+            oftWrapper.setCallerBpsCap(_callerBpsCap);
+        } else {
+            oftWrapper.setCallerBpsCap(_callerBpsCap);
+            assertEq(_callerBpsCap, oftWrapper.callerBpsCap());
+        }
+    }
+
+    function _assumeThenSetCallerBpsCap(uint256 _callerBps, uint256 _callerBpsCap) public {
+        vm.assume(_callerBps > _callerBpsCap && _callerBps < oftWrapper.BPS_DENOMINATOR());
+        oftWrapper.setCallerBpsCap(_callerBpsCap);
+    }
+
+    function test_sendOFT_ExcessiveCallerBps(
+        uint16 _callerBpsCap,
+        address _oft,
+        uint16 _dstChainId,
+        bytes calldata _toAddress,
+        uint256 _amount,
+        uint256 _minAmount,
+        address payable _refundAddress,
+        address _zroPaymentAddress,
+        bytes calldata _adapterParams,
+        uint16 _callerBps
+    ) public {
+        _assumeThenSetCallerBpsCap(_callerBps, _callerBpsCap);
+        vm.expectRevert(EXCESSIVE_CALLER_BPS_ERROR);
+        oftWrapper.sendOFT(
+            _oft,
+            _dstChainId,
+            _toAddress,
+            _amount,
+            _minAmount,
+            _refundAddress,
+            _zroPaymentAddress,
+            _adapterParams,
+            _createFeeObj(_callerBps, address(this), bytes2(0x0034))
+        );
+    }
+
+    function test_sendProxyOFT_ExcessiveCallerBps(
+        uint16 _callerBpsCap,
+        address _oft,
+        uint16 _dstChainId,
+        bytes calldata _toAddress,
+        uint256 _amount,
+        uint256 _minAmount,
+        address payable _refundAddress,
+        address _zroPaymentAddress,
+        bytes calldata _adapterParams,
+        uint16 _callerBps
+    ) public {
+        _assumeThenSetCallerBpsCap(_callerBps, _callerBpsCap);
+        vm.expectRevert(EXCESSIVE_CALLER_BPS_ERROR);
+        oftWrapper.sendProxyOFT(
+            _oft,
+            _dstChainId,
+            _toAddress,
+            _amount,
+            _minAmount,
+            _refundAddress,
+            _zroPaymentAddress,
+            _adapterParams,
+            _createFeeObj(_callerBps, address(this), bytes2(0x0034))
+        );
+    }
+
+    function test_sendNativeOFT_ExcessiveCallerBps(
+        uint16 _callerBpsCap,
+        address _oft,
+        uint16 _dstChainId,
+        bytes calldata _toAddress,
+        uint256 _amount,
+        uint256 _minAmount,
+        address payable _refundAddress,
+        address _zroPaymentAddress,
+        bytes calldata _adapterParams,
+        uint16 _callerBps
+    ) public {
+        _assumeThenSetCallerBpsCap(_callerBps, _callerBpsCap);
+        vm.expectRevert(EXCESSIVE_CALLER_BPS_ERROR);
+        oftWrapper.sendNativeOFT(
+            _oft,
+            _dstChainId,
+            _toAddress,
+            _amount,
+            _minAmount,
+            _refundAddress,
+            _zroPaymentAddress,
+            _adapterParams,
+            _createFeeObj(_callerBps, address(this), bytes2(0x0034))
+        );
+    }
+
+    function test_sendOFTV2_ExcessiveCallerBps(
+        uint16 _callerBpsCap,
+        address _oft,
+        uint16 _dstChainId,
+        bytes32 _toAddress,
+        uint256 _amount,
+        uint256 _minAmount,
+        uint16 _callerBps
+    ) public {
+        _assumeThenSetCallerBpsCap(_callerBps, _callerBpsCap);
+        vm.expectRevert(EXCESSIVE_CALLER_BPS_ERROR);
+        oftWrapper.sendOFTV2(
+            _oft,
+            _dstChainId,
+            _toAddress,
+            _amount,
+            _minAmount,
+            ICommonOFT.LzCallParams(payable(address(this)), address(this), ""),
+            _createFeeObj(_callerBps, address(this), bytes2(0x0034))
+        );
+    }
+
+    function test_sendOFTFeeV2_ExcessiveCallerBps(
+        uint16 _callerBpsCap,
+        address _oft,
+        uint16 _dstChainId,
+        bytes32 _toAddress,
+        uint256 _amount,
+        uint256 _minAmount,
+        uint16 _callerBps
+    ) public {
+        _assumeThenSetCallerBpsCap(_callerBps, _callerBpsCap);
+        vm.expectRevert(EXCESSIVE_CALLER_BPS_ERROR);
+        oftWrapper.sendOFTFeeV2(
+            _oft,
+            _dstChainId,
+            _toAddress,
+            _amount,
+            _minAmount,
+            ICommonOFT.LzCallParams(payable(address(this)), address(this), ""),
+            _createFeeObj(_callerBps, address(this), bytes2(0x0034))
+        );
+    }
+
+    function test_sendProxyOFTV2_ExcessiveCallerBps(
+        uint16 _callerBpsCap,
+        address _oft,
+        uint16 _dstChainId,
+        bytes32 _toAddress,
+        uint256 _amount,
+        uint256 _minAmount,
+        uint16 _callerBps
+    ) public {
+        _assumeThenSetCallerBpsCap(_callerBps, _callerBpsCap);
+        vm.expectRevert(EXCESSIVE_CALLER_BPS_ERROR);
+        oftWrapper.sendProxyOFTV2(
+            _oft,
+            _dstChainId,
+            _toAddress,
+            _amount,
+            _minAmount,
+            ICommonOFT.LzCallParams(payable(address(this)), address(this), ""),
+            _createFeeObj(_callerBps, address(this), bytes2(0x0034))
+        );
+    }
+
+    function test_sendProxyOFTFeeV2_ExcessiveCallerBps(
+        uint16 _callerBpsCap,
+        address _oft,
+        uint16 _dstChainId,
+        bytes32 _toAddress,
+        uint256 _amount,
+        uint256 _minAmount,
+        uint16 _callerBps
+    ) public {
+        _assumeThenSetCallerBpsCap(_callerBps, _callerBpsCap);
+        vm.expectRevert(EXCESSIVE_CALLER_BPS_ERROR);
+        oftWrapper.sendProxyOFTFeeV2(
+            _oft,
+            _dstChainId,
+            _toAddress,
+            _amount,
+            _minAmount,
+            ICommonOFT.LzCallParams(payable(address(this)), address(this), ""),
+            _createFeeObj(_callerBps, address(this), bytes2(0x0034))
+        );
+    }
+
+    function test_sendNativeOFTFeeV2_ExcessiveCallerBps(
+        uint16 _callerBpsCap,
+        address _oft,
+        uint16 _dstChainId,
+        bytes32 _toAddress,
+        uint256 _amount,
+        uint256 _minAmount,
+        uint16 _callerBps
+    ) public {
+        _assumeThenSetCallerBpsCap(_callerBps, _callerBpsCap);
+        vm.expectRevert(EXCESSIVE_CALLER_BPS_ERROR);
+        oftWrapper.sendNativeOFTFeeV2(
+            _oft,
+            _dstChainId,
+            _toAddress,
+            _amount,
+            _minAmount,
+            ICommonOFT.LzCallParams(payable(address(this)), address(this), ""),
+            _createFeeObj(_callerBps, address(this), bytes2(0x0034))
+        );
+    }
+
+    function test_sendOFTEpv2_ExcessiveCallerBps(
+        uint16 _callerBpsCap,
+        address _oft,
+        address _refundAddress,
+        uint16 _callerBps
+    ) public {
+        _assumeThenSetCallerBpsCap(_callerBps, _callerBpsCap);
+
+        SendParamEpv2 memory _sendParam = SendParamEpv2(
+            B_EID,
+            _addressToBytes32(receiver),
+            IERC20(oft).balanceOf(receiver),
+            0,
+            OptionsBuilder.newOptions().addExecutorLzReceiveOption(200_000, 0),
+            "",
+            ""
+        );
+        vm.expectRevert(EXCESSIVE_CALLER_BPS_ERROR);
+        oftWrapper.sendOFTEpv2(
+            _oft,
+            _sendParam,
+            MessagingFeeEpv2(100_000, 0),
+            _refundAddress,
+            _createFeeObj(_callerBps, address(this), bytes2(0x0034))
+        );
+    }
+
+    function test_sendOFTAdapterEpv2_ExcessiveCallerBps(
+        uint16 _callerBpsCap,
+        address _oft,
+        address _refundAddress,
+        uint16 _callerBps
+    ) public {
+        _assumeThenSetCallerBpsCap(_callerBps, _callerBpsCap);
+        SendParamEpv2 memory _sendParam = SendParamEpv2(
+            B_EID,
+            _addressToBytes32(receiver),
+            IERC20(oft).balanceOf(receiver),
+            0,
+            OptionsBuilder.newOptions().addExecutorLzReceiveOption(200_000, 0),
+            "",
+            ""
+        );
+        vm.expectRevert(EXCESSIVE_CALLER_BPS_ERROR);
+        oftWrapper.sendOFTEpv2(
+            _oft,
+            _sendParam,
+            MessagingFeeEpv2(100_000, 0),
+            _refundAddress,
+            _createFeeObj(_callerBps, address(this), bytes2(0x0034))
+        );
+    }
+
+    function test_getAmountAndFees_ExcessiveCallerBps(uint16 _callerBpsCap, uint256 _amount, uint16 _callerBps) public {
+        _assumeThenSetCallerBpsCap(_callerBps, _callerBpsCap);
+        vm.expectRevert(EXCESSIVE_CALLER_BPS_ERROR);
+        oftWrapper.getAmountAndFees(address(this), _amount, _callerBps);
+    }
+
+    function test_estimateSendFee_ExcessiveCallerBps(uint256 _callerBpsCap, uint256 _amount, uint16 _callerBps) public {
+        _assumeThenSetCallerBpsCap(_callerBps, _callerBpsCap);
+        vm.expectRevert(EXCESSIVE_CALLER_BPS_ERROR);
+        oftWrapper.estimateSendFee(
+            address(this),
+            1,
+            "",
+            _amount,
+            false,
+            "",
+            _createFeeObj(_callerBps, address(this), bytes2(0x0034))
+        );
+    }
+
+    function test_estimateSendFeeV2_ExcessiveCallerBps(
+        uint256 _callerBpsCap,
+        uint256 _amount,
+        uint16 _callerBps
+    ) public {
+        _assumeThenSetCallerBpsCap(_callerBps, _callerBpsCap);
+        vm.expectRevert(EXCESSIVE_CALLER_BPS_ERROR);
+        oftWrapper.estimateSendFeeV2(
+            address(this),
+            1,
+            "",
+            _amount,
+            false,
+            "",
+            _createFeeObj(_callerBps, address(this), bytes2(0x0034))
+        );
+    }
+
+    function test_estimateSendFeeEpv2_ExcessiveCallerBps(
+        uint256 _callerBpsCap,
+        uint256 _amount,
+        uint16 _callerBps
+    ) public {
+        _assumeThenSetCallerBpsCap(_callerBps, _callerBpsCap);
+        vm.expectRevert(EXCESSIVE_CALLER_BPS_ERROR);
+        oftWrapper.estimateSendFeeEpv2(
+            address(this),
+            SendParamEpv2(1, "", _amount, 0, OptionsBuilder.newOptions(), "", ""),
+            false,
+            _createFeeObj(_callerBps, address(this), bytes2(0x0034))
+        );
     }
 }


### PR DESCRIPTION
This helps avoid caller applications to OFTWrapper from setting fee bps arbitrarily high.  This is not needed for the defaultBps, as only the owner can set that.