### PR TITLE
🧹 Specify confirmations for EBI

### DIFF
--- a/.changeset/fast-wombats-smell.md
+++ b/.changeset/fast-wombats-smell.md
@@ -1,0 +1,6 @@
+---
+"@stargatefinance/stg-definitions-v2": patch
+"@stargatefinance/stg-evm-v2": patch
+---
+
+Specify confirmation for Credit & Token messaging

--- a/packages/stg-definitions-v2/src/constant.ts
+++ b/packages/stg-definitions-v2/src/constant.ts
@@ -798,12 +798,14 @@ export const NETWORKS: NetworksConfig = {
             ...DEFAULT_CREDIT_MESSAGING_NETWORK_CONFIG,
             requiredDVNs: [DVNS.NETHERMIND[EndpointId.EBI_V2_MAINNET], DVNS.STG[EndpointId.EBI_V2_MAINNET]],
             executor: EXECUTORS.LZ_LABS[EndpointId.EBI_V2_MAINNET],
+            confirmations: BigInt(50),
         },
         tokenMessaging: {
             ...DEFAULT_TOKEN_MESSAGING_NETWORK_CONFIG,
             requiredDVNs: [DVNS.NETHERMIND[EndpointId.EBI_V2_MAINNET], DVNS.STG[EndpointId.EBI_V2_MAINNET]],
             executor: EXECUTORS.LZ_LABS[EndpointId.EBI_V2_MAINNET],
             nativeDropAmount: parseEther('0.00003').toBigInt(),
+            confirmations: BigInt(50),
         },
         safeConfig: {
             safeAddress: '0xb93Aa694A3De8662E1ca9aD0C811440E48cDFe5E',

--- a/packages/stg-definitions-v2/src/types.ts
+++ b/packages/stg-definitions-v2/src/types.ts
@@ -91,6 +91,7 @@ export interface CreditMessagingNetworkConfig {
     sendCreditGasLimit: bigint
     requiredDVNs?: string[]
     executor?: string
+    confirmations?: bigint
 }
 
 export interface TokenMessagingNetworkConfig {
@@ -103,6 +104,7 @@ export interface TokenMessagingNetworkConfig {
     requiredDVNs?: string[]
     executor?: string
     queueCapacity: number
+    confirmations?: bigint
 }
 
 export interface OftWrapperConfig {

--- a/packages/stg-evm-v2/devtools/config/utils.ts
+++ b/packages/stg-evm-v2/devtools/config/utils.ts
@@ -85,11 +85,13 @@ const toCreditMessagingEdgeConfig = (
             : undefined,
         ulnConfig: {
             requiredDVNs: fromConfig.requiredDVNs ?? [],
+            confirmations: fromConfig.confirmations,
         },
     },
     receiveConfig: {
         ulnConfig: {
             requiredDVNs: fromConfig.requiredDVNs ?? [],
+            confirmations: fromConfig.confirmations,
         },
     },
 })
@@ -140,11 +142,13 @@ const toTokenMessagingEdgeConfig = (
             : undefined,
         ulnConfig: {
             requiredDVNs: fromConfig.requiredDVNs ?? [],
+            confirmations: fromConfig.confirmations,
         },
     },
     receiveConfig: {
         ulnConfig: {
             requiredDVNs: fromConfig.requiredDVNs ?? [],
+            confirmations: fromConfig.confirmations,
         },
     },
 })


### PR DESCRIPTION
### In this PR

- Add `confirmations` to configuration types for token & credit messaging
- Set the confirmations to `50` for EBI