### PR TITLE
🧹 Split mainnet configuration target

### DIFF
--- a/.github/workflows/reusable-configure.yaml
+++ b/.github/workflows/reusable-configure.yaml
@@ -121,6 +121,14 @@ jobs:
           # Run under simulation
           LZ_EXPERIMENTAL_WITH_SIMULATION: 1
 
+      - name: Preconfigure mainnet (simulation)
+        run: make preconfigure-mainnet CONFIGURE_ARGS_COMMON=--ci
+        env:
+          LZ_ENABLE_EXPERIMENTAL_PARALLEL_EXECUTION: 1
+          LZ_ENABLE_EXPERIMENTAL_BATCHED_WAIT: 1
+          # Run under simulation
+          LZ_EXPERIMENTAL_WITH_SIMULATION: 1
+
       - name: Configure mainnet (simulation)
         run: make configure-mainnet CONFIGURE_ARGS_COMMON=--ci
         env:

--- a/Makefile
+++ b/Makefile
@@ -235,11 +235,11 @@ deploy-mainnet: DEPLOY_ARGS=--stage mainnet
 deploy-mainnet: build deploy
 
 # 
-# This target will configure the mainnet contracts
+# This target will configure everything that is easier to configure with a hot wallet
 # 
 
-configure-mainnet: CONFIG_BASE_PATH=./devtools/config/mainnet/01
-configure-mainnet:
+preconfigure-mainnet: CONFIG_BASE_PATH=./devtools/config/mainnet/01
+preconfigure-mainnet:
 	# Configure the OFTs
 	$(CONFIGURE_OFT) $(CONFIGURE_ARGS_COMMON) --oapp-config $(CONFIG_BASE_PATH)/oft-token.config.ts --signer deployer
 
@@ -252,6 +252,12 @@ configure-mainnet:
 	# Configure everything else for USDC
 	$(CONFIGURE_USDC) $(CONFIGURE_ARGS_COMMON) --oapp-config $(CONFIG_BASE_PATH)/usdc-token.config.ts --signer deployer
 
+# 
+# This target will configure the mainnet contracts
+# 
+
+configure-mainnet: CONFIG_BASE_PATH=./devtools/config/mainnet/01
+configure-mainnet:
 	# Configure the assets
 	$(CONFIGURE_ASSET) $(CONFIGURE_ARGS_COMMON) --oapp-config $(CONFIG_BASE_PATH)/asset.eth.config.ts --signer deployer
 	$(CONFIGURE_ASSET) $(CONFIGURE_ARGS_COMMON) --oapp-config $(CONFIG_BASE_PATH)/asset.meth.config.ts --signer deployer
@@ -329,18 +335,10 @@ transfer-mainnet:
 	# Configure OFT wrapper
 	$(TRANSFER_OWNERSHIP) $(CONFIGURE_ARGS_COMMON) --oapp-config $(CONFIG_BASE_PATH)/oft-wrapper.config.ts --signer deployer
 
-# Please be careful with this target, I'd much rather you run
+# Please be careful with this target, I'd much rather you run the commands one by one
 # 
 # make deploy-mainnet
-# make configure-mainnet
-# 
-# Then rerun 
-# 
-# make configure-mainnet
-# 
-# Like seven times
-# 
-# And only then
-# 
+# make preconfigure-mainnet
 # make transfer-mainnet
-mainnet: deploy-mainnet configure-mainnet transfer-mainnet
+# make configure-mainnet
+mainnet: deploy-mainnet preconfigure-mainnet transfer-mainnet configure-mainnet

--- a/packages/stg-evm-v2/DEPLOYMENT.md
+++ b/packages/stg-evm-v2/DEPLOYMENT.md
@@ -141,19 +141,15 @@ LZ_ENABLE_EXPERIMENTAL_PARALLEL_EXECUTION=1 LZ_ENABLE_EXPERIMENTAL_RETRY=1 make 
 The safe way of doing this though is
 
 ```bash
+# First the contracts are deployed
 make deploy-mainnet
-make configure-mainnet
+# The the OFT/USDC contracts are configured with a hot wallet
+make preconfigure-mainnet
+# Then the ownership is transferred to the multisig
 make transfer-mainnet
-```
-
-After the mainnet has been transferred to the multisig, any new changes need to be submitted using the safe signer:
-
-```bash
-make configure-mainnet CONFIGURE_ARGS_COMMON="--safe"
-```
-
-Safe signer also supports batched mode that's currently feature-flagged in devtools:
-
-```bash
+# The the rest of the configuration is executed using a multisig
+#
+# The LZ_ENABLE_EXPERIMENTAL_BATCHED_SEND feature flag is used to reduce
+# the amount of transactions that need to be signed
 LZ_ENABLE_EXPERIMENTAL_BATCHED_SEND=1 make configure-mainnet CONFIGURE_ARGS_COMMON="--safe"
 ```


### PR DESCRIPTION
### In this PR

- Split the `configure-mainnet` `make` target into two
  - `preconfigure-mainnet` can be run with a hot wallet, it will setup the OFT/USDC contracts
  - `configure-mainnet` is then run after the ownership has been transferred and is run using the multisig
- The sequence of configuration then becomes:
  - `preconfigure-mainnet`
  - `transfer-mainnet`
  - `configure-mainnet`