### PR TITLE
🧹 Disable gas profiling workflows because we don't like them anymore

### DIFF
--- a/.github/workflows/on-main.yaml
+++ b/.github/workflows/on-main.yaml
@@ -27,6 +27,10 @@ jobs:
     secrets: inherit
 
   update-gas:
+    #
+    # Disabled because we don't like it
+    #
+    if: false
     name: Update gas
     uses: ./.github/workflows/reusable-gas-snapshot.yaml
     secrets: inherit

--- a/.github/workflows/reusable-test.yaml
+++ b/.github/workflows/reusable-test.yaml
@@ -37,6 +37,10 @@ jobs:
           RPC_URL_ETHEREUM_MAINNET: ${{ secrets.RPC_URL_ETHEREUM_MAINNET || 'https://rpc.ankr.com/eth' }}
 
   profile-gas:
+    #
+    # Disabled because we don't like it
+    #
+    if: false
     name: Profile gas
     runs-on: ubuntu-latest-4xlarge
     steps:
@@ -83,6 +87,10 @@ jobs:
             ${{ steps.profile-gas.outputs.gas-report }}
 
   diff-gas:
+    #
+    # Disabled because we don't like it
+    #
+    if: false
     name: Diff gas
     runs-on: ubuntu-latest-4xlarge
     steps:


### PR DESCRIPTION
### In this PR

- Before we investigate the performance degradation of the gas profiling workflows, we disable them