### PR TITLE
🪲 Fix deployments export

### DIFF
--- a/packages/stg-definitions-v2/package.json
+++ b/packages/stg-definitions-v2/package.json
@@ -27,7 +27,7 @@
     "@safe-global/protocol-kit": "^1.3.0",
     "@types/node": "^18.15.11",
     "tsup": "^8.0.1",
-    "typescript": "~5.5.3"
+    "typescript": "~5.6.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/stg-devtools-evm-hardhat-v2/package.json
+++ b/packages/stg-devtools-evm-hardhat-v2/package.json
@@ -43,7 +43,7 @@
     "esbuild-plugin-copy": "~2.1.1",
     "ts-node": "^10.9.1",
     "tsup": "^8.0.1",
-    "typescript": "~5.5.3",
+    "typescript": "~5.6.3",
     "zod": "~3.22.4"
   },
   "peerDependencies": {

--- a/packages/stg-devtools-evm-hardhat-v2/src/credit-messaging/schema.ts
+++ b/packages/stg-devtools-evm-hardhat-v2/src/credit-messaging/schema.ts
@@ -1,12 +1,22 @@
-import { CreditMessagingEdgeConfigSchema, CreditMessagingNodeConfigSchema } from '@stargatefinance/stg-devtools-v2'
+import {
+    type CreditMessagingEdgeConfig,
+    CreditMessagingEdgeConfigSchema,
+    type CreditMessagingNodeConfig,
+    CreditMessagingNodeConfigSchema,
+} from '@stargatefinance/stg-devtools-v2'
 
 import {
+    type OmniGraphHardhat,
     createOmniEdgeHardhatSchema,
     createOmniGraphHardhatSchema,
     createOmniNodeHardhatSchema,
 } from '@layerzerolabs/devtools-evm-hardhat'
 
-export const CreditMessagingOmniGraphHardhatSchema = createOmniGraphHardhatSchema(
+export const CreditMessagingOmniGraphHardhatSchema: Zod.ZodSchema<
+    OmniGraphHardhat<CreditMessagingNodeConfig, CreditMessagingEdgeConfig>,
+    Zod.ZodTypeDef,
+    unknown
+> = createOmniGraphHardhatSchema(
     createOmniNodeHardhatSchema(CreditMessagingNodeConfigSchema),
     createOmniEdgeHardhatSchema(CreditMessagingEdgeConfigSchema)
 )

--- a/packages/stg-devtools-evm-hardhat-v2/src/token-messaging/schema.ts
+++ b/packages/stg-devtools-evm-hardhat-v2/src/token-messaging/schema.ts
@@ -1,12 +1,22 @@
-import { TokenMessagingEdgeConfigSchema, TokenMessagingNodeConfigSchema } from '@stargatefinance/stg-devtools-v2'
+import {
+    type TokenMessagingEdgeConfig,
+    TokenMessagingEdgeConfigSchema,
+    type TokenMessagingNodeConfig,
+    TokenMessagingNodeConfigSchema,
+} from '@stargatefinance/stg-devtools-v2'
 
 import {
+    type OmniGraphHardhat,
     createOmniEdgeHardhatSchema,
     createOmniGraphHardhatSchema,
     createOmniNodeHardhatSchema,
 } from '@layerzerolabs/devtools-evm-hardhat'
 
-export const TokenMessagingOmniGraphHardhatSchema = createOmniGraphHardhatSchema(
+export const TokenMessagingOmniGraphHardhatSchema: Zod.ZodSchema<
+    OmniGraphHardhat<TokenMessagingNodeConfig, TokenMessagingEdgeConfig>,
+    Zod.ZodTypeDef,
+    unknown
+> = createOmniGraphHardhatSchema(
     createOmniNodeHardhatSchema(TokenMessagingNodeConfigSchema),
     createOmniEdgeHardhatSchema(TokenMessagingEdgeConfigSchema)
 )

--- a/packages/stg-devtools-v2/package.json
+++ b/packages/stg-devtools-v2/package.json
@@ -31,7 +31,7 @@
     "@types/node": "^18.15.11",
     "ts-node": "^10.9.1",
     "tsup": "^8.0.1",
-    "typescript": "~5.5.3",
+    "typescript": "~5.6.3",
     "zod": "~3.22.4"
   },
   "peerDependencies": {

--- a/packages/stg-error-parser/package.json
+++ b/packages/stg-error-parser/package.json
@@ -31,7 +31,7 @@
     "ts-jest": "^29.1.1",
     "ts-node": "^10.9.1",
     "tsup": "^8.0.1",
-    "typescript": "~5.5.3"
+    "typescript": "~5.6.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/stg-evm-sdk-v2/package.json
+++ b/packages/stg-evm-sdk-v2/package.json
@@ -48,7 +48,7 @@
     "esbuild-plugin-copy": "~2.1.1",
     "ts-node": "^10.9.1",
     "tsup": "^8.0.1",
-    "typescript": "~5.5.3"
+    "typescript": "~5.6.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/stg-evm-v2/package.json
+++ b/packages/stg-evm-v2/package.json
@@ -99,7 +99,7 @@
     "@layerzerolabs/devtools": "~0.3.18",
     "@layerzerolabs/devtools-evm": "~0.3.13",
     "@layerzerolabs/devtools-evm-hardhat": "~0.3.22",
-    "@layerzerolabs/export-deployments": "~0.0.11",
+    "@layerzerolabs/export-deployments": "~0.0.10",
     "@layerzerolabs/io-devtools": "~0.1.11",
     "@layerzerolabs/lz-evm-sdk-v1": "~3.0.7",
     "@layerzerolabs/protocol-devtools": "~0.3.9",
@@ -149,7 +149,7 @@
     "ts-node": "^10.9.1",
     "tsup": "^8.0.1",
     "typechain": "~8.3.2",
-    "typescript": "~5.5.3",
+    "typescript": "~5.6.3",
     "zod": "~3.22.4"
   },
   "publishConfig": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,13 +139,13 @@ importers:
         version: 2.1.1(esbuild@0.24.0)
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.2(@types/node@18.19.31)(typescript@5.5.3)
+        version: 10.9.2(@types/node@18.19.31)(typescript@5.6.3)
       tsup:
         specifier: ^8.0.1
-        version: 8.0.2(ts-node@10.9.2)(typescript@5.5.3)
+        version: 8.0.2(ts-node@10.9.2)(typescript@5.6.3)
       typescript:
-        specifier: ~5.5.3
-        version: 5.5.3
+        specifier: ~5.6.3
+        version: 5.6.3
       zod:
         specifier: ~3.22.4
         version: 3.22.5
@@ -178,13 +178,13 @@ importers:
         version: 18.19.31
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.2(@types/node@18.19.31)(typescript@5.5.3)
+        version: 10.9.2(@types/node@18.19.31)(typescript@5.6.3)
       tsup:
         specifier: ^8.0.1
-        version: 8.0.2(ts-node@10.9.2)(typescript@5.5.3)
+        version: 8.0.2(ts-node@10.9.2)(typescript@5.6.3)
       typescript:
-        specifier: ~5.5.3
-        version: 5.5.3
+        specifier: ~5.6.3
+        version: 5.6.3
       zod:
         specifier: ~3.22.4
         version: 3.22.5
@@ -197,7 +197,7 @@ importers:
     devDependencies:
       '@layerzerolabs/tsup-config-next':
         specifier: ~3.0.7
-        version: 3.0.7(ts-node@10.9.2)(typescript@5.5.3)
+        version: 3.0.7(ts-node@10.9.2)(typescript@5.6.3)
       '@layerzerolabs/typescript-config-next':
         specifier: ~3.0.7
         version: 3.0.7
@@ -218,22 +218,22 @@ importers:
         version: 3.2.5
       ts-jest:
         specifier: ^29.1.1
-        version: 29.1.3(@babel/core@7.24.4)(esbuild@0.19.12)(jest@29.7.0)(typescript@5.5.3)
+        version: 29.1.3(@babel/core@7.24.4)(esbuild@0.19.12)(jest@29.7.0)(typescript@5.6.3)
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.2(@types/node@18.19.31)(typescript@5.5.3)
+        version: 10.9.2(@types/node@18.19.31)(typescript@5.6.3)
       tsup:
         specifier: ^8.0.1
-        version: 8.0.2(ts-node@10.9.2)(typescript@5.5.3)
+        version: 8.0.2(ts-node@10.9.2)(typescript@5.6.3)
       typescript:
-        specifier: ~5.5.3
-        version: 5.5.3
+        specifier: ~5.6.3
+        version: 5.6.3
 
   packages/stg-evm-sdk-v2:
     devDependencies:
       '@layerzerolabs/tsup-config-next':
         specifier: ~3.0.7
-        version: 3.0.7(ts-node@10.9.2)(typescript@5.5.3)
+        version: 3.0.7(ts-node@10.9.2)(typescript@5.6.3)
       '@layerzerolabs/typescript-config-next':
         specifier: ~3.0.7
         version: 3.0.7
@@ -251,13 +251,13 @@ importers:
         version: 2.1.1(esbuild@0.24.0)
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.2(@types/node@18.19.31)(typescript@5.5.3)
+        version: 10.9.2(@types/node@18.19.31)(typescript@5.6.3)
       tsup:
         specifier: ^8.0.1
-        version: 8.0.2(ts-node@10.9.2)(typescript@5.5.3)
+        version: 8.0.2(ts-node@10.9.2)(typescript@5.6.3)
       typescript:
-        specifier: ~5.5.3
-        version: 5.5.3
+        specifier: ~5.6.3
+        version: 5.6.3
 
   packages/stg-evm-v2:
     dependencies:
@@ -2492,7 +2492,7 @@ packages:
       '@nomiclabs/hardhat-ethers': 2.2.3(ethers@5.7.2)(hardhat@2.22.14)
       '@safe-global/protocol-kit': 1.3.0(ethers@5.7.2)
       fp-ts: 2.16.9
-      hardhat: 2.22.14(ts-node@10.9.2)(typescript@5.5.3)
+      hardhat: 2.22.14(ts-node@10.9.2)(typescript@5.6.3)
       hardhat-deploy: 0.12.4
       micro-memoize: 4.1.2
       p-memoize: 4.0.4
@@ -3127,22 +3127,6 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@layerzerolabs/tsup-config-next@3.0.7(ts-node@10.9.2)(typescript@5.5.3):
-    resolution: {integrity: sha512-nNhkcmyUce2P8i0i2kd5+PutUeXaHQ9aSkYnBn6W9Z4/yoO/hBsAYMUR3FMu2e17bybDIcqWt2EEQmBb3XDHjw==}
-    dependencies:
-      '@chialab/esbuild-plugin-commonjs': 0.17.2
-      esbuild: 0.19.12
-      esbuild-node-externals: 1.15.0(esbuild@0.19.12)
-      tsup: 8.0.2(ts-node@10.9.2)(typescript@5.5.3)
-    transitivePeerDependencies:
-      - '@microsoft/api-extractor'
-      - '@swc/core'
-      - postcss
-      - supports-color
-      - ts-node
-      - typescript
-    dev: true
-
   /@layerzerolabs/tsup-config-next@3.0.7(ts-node@10.9.2)(typescript@5.6.3):
     resolution: {integrity: sha512-nNhkcmyUce2P8i0i2kd5+PutUeXaHQ9aSkYnBn6W9Z4/yoO/hBsAYMUR3FMu2e17bybDIcqWt2EEQmBb3XDHjw==}
     dependencies:
@@ -3277,7 +3261,7 @@ packages:
       '@layerzerolabs/ua-devtools': 0.3.20(@layerzerolabs/devtools@0.3.18)(@layerzerolabs/io-devtools@0.1.11)(@layerzerolabs/lz-definitions@3.0.7)(@layerzerolabs/lz-v2-utilities@3.0.7)(@layerzerolabs/protocol-devtools@0.3.9)(zod@3.22.5)
       '@layerzerolabs/ua-devtools-evm': 0.3.15(@ethersproject/constants@5.7.0)(@ethersproject/contracts@5.7.0)(@layerzerolabs/devtools-evm@0.3.13)(@layerzerolabs/devtools@0.3.18)(@layerzerolabs/io-devtools@0.1.11)(@layerzerolabs/lz-definitions@3.0.7)(@layerzerolabs/lz-v2-utilities@3.0.7)(@layerzerolabs/protocol-devtools-evm@0.3.10)(@layerzerolabs/protocol-devtools@0.3.9)(@layerzerolabs/ua-devtools@0.3.20)(zod@3.22.5)
       ethers: 5.7.2
-      hardhat: 2.22.14(ts-node@10.9.2)(typescript@5.5.3)
+      hardhat: 2.22.14(ts-node@10.9.2)(typescript@5.6.3)
       hardhat-deploy: 0.12.4
       p-memoize: 4.0.4
       typescript: 5.6.3
@@ -4041,7 +4025,7 @@ packages:
       hardhat: ^2.0.0
     dependencies:
       ethers: 5.7.2
-      hardhat: 2.22.14(ts-node@10.9.2)(typescript@5.5.3)
+      hardhat: 2.22.14(ts-node@10.9.2)(typescript@5.6.3)
     dev: true
 
   /@nomiclabs/hardhat-ethers@2.2.3(ethers@5.7.2)(hardhat@2.22.3):
@@ -9288,7 +9272,7 @@ packages:
       hardhat: 2.22.3(ts-node@10.9.2)(typescript@5.6.3)
     dev: true
 
-  /hardhat@2.22.14(ts-node@10.9.2)(typescript@5.5.3):
+  /hardhat@2.22.14(ts-node@10.9.2)(typescript@5.6.3):
     resolution: {integrity: sha512-sD8vHtS9l5QQVHzyPPe3auwZDJyZ0fG3Z9YENVa4oOqVEefCuHcPzdU736rei3zUKTqkX0zPIHkSMHpu02Fq1A==}
     hasBin: true
     peerDependencies:
@@ -9340,9 +9324,9 @@ packages:
       solc: 0.8.26(debug@4.3.7)
       source-map-support: 0.5.21
       stacktrace-parser: 0.1.10
-      ts-node: 10.9.2(@types/node@18.19.31)(typescript@5.5.3)
+      ts-node: 10.9.2(@types/node@18.19.31)(typescript@5.6.3)
       tsort: 0.0.1
-      typescript: 5.5.3
+      typescript: 5.6.3
       undici: 5.28.4
       uuid: 8.3.2
       ws: 7.5.10
@@ -10280,7 +10264,7 @@ packages:
       pretty-format: 29.7.0
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.2(@types/node@18.19.31)(typescript@5.5.3)
+      ts-node: 10.9.2(@types/node@18.19.31)(typescript@5.6.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -12067,7 +12051,7 @@ packages:
         optional: true
     dependencies:
       lilconfig: 3.0.0
-      ts-node: 10.9.2(@types/node@18.19.31)(typescript@5.5.3)
+      ts-node: 10.9.2(@types/node@18.19.31)(typescript@5.6.3)
       yaml: 2.3.4
     dev: true
 
@@ -14006,7 +13990,7 @@ packages:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
     dev: true
 
-  /ts-jest@29.1.3(@babel/core@7.24.4)(esbuild@0.19.12)(jest@29.7.0)(typescript@5.5.3):
+  /ts-jest@29.1.3(@babel/core@7.24.4)(esbuild@0.19.12)(jest@29.7.0)(typescript@5.6.3):
     resolution: {integrity: sha512-6L9qz3ginTd1NKhOxmkP0qU3FyKjj5CPoY+anszfVn6Pmv/RIKzhiMCsH7Yb7UvJR9I2A64rm4zQl531s2F1iw==}
     engines: {node: ^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -14040,7 +14024,7 @@ packages:
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.6.2
-      typescript: 5.5.3
+      typescript: 5.6.3
       yargs-parser: 21.1.1
     dev: true
 
@@ -14049,37 +14033,6 @@ packages:
     dependencies:
       '@ts-morph/common': 0.22.0
       code-block-writer: 12.0.0
-    dev: true
-
-  /ts-node@10.9.2(@types/node@18.19.31)(typescript@5.5.3):
-    resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
-    hasBin: true
-    peerDependencies:
-      '@swc/core': '>=1.2.50'
-      '@swc/wasm': '>=1.2.50'
-      '@types/node': '*'
-      typescript: '>=2.7'
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      '@swc/wasm':
-        optional: true
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.11
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 18.19.31
-      acorn: 8.11.3
-      acorn-walk: 8.3.2
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 5.5.3
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
     dev: true
 
   /ts-node@10.9.2(@types/node@18.19.31)(typescript@5.6.3):
@@ -14138,45 +14091,6 @@ packages:
 
   /tsort@0.0.1:
     resolution: {integrity: sha512-Tyrf5mxF8Ofs1tNoxA13lFeZ2Zrbd6cKbuH3V+MQ5sb6DtBj5FjrXVsRWT8YvNAQTqNoz66dz1WsbigI22aEnw==}
-    dev: true
-
-  /tsup@8.0.2(ts-node@10.9.2)(typescript@5.5.3):
-    resolution: {integrity: sha512-NY8xtQXdH7hDUAZwcQdY/Vzlw9johQsaqf7iwZ6g1DOUlFYQ5/AtVAjTvihhEyeRlGo4dLRVHtrRaL35M1daqQ==}
-    engines: {node: '>=18'}
-    hasBin: true
-    peerDependencies:
-      '@microsoft/api-extractor': ^7.36.0
-      '@swc/core': ^1
-      postcss: ^8.4.12
-      typescript: '>=4.5.0'
-    peerDependenciesMeta:
-      '@microsoft/api-extractor':
-        optional: true
-      '@swc/core':
-        optional: true
-      postcss:
-        optional: true
-      typescript:
-        optional: true
-    dependencies:
-      bundle-require: 4.0.3(esbuild@0.19.12)
-      cac: 6.7.14
-      chokidar: 3.6.0
-      debug: 4.3.5
-      esbuild: 0.19.12
-      execa: 5.1.1
-      globby: 11.1.0
-      joycon: 3.1.1
-      postcss-load-config: 4.0.2(ts-node@10.9.2)
-      resolve-from: 5.0.0
-      rollup: 4.16.4
-      source-map: 0.8.0-beta.0
-      sucrase: 3.35.0
-      tree-kill: 1.2.2
-      typescript: 5.5.3
-    transitivePeerDependencies:
-      - supports-color
-      - ts-node
     dev: true
 
   /tsup@8.0.2(ts-node@10.9.2)(typescript@5.6.3):
@@ -14468,12 +14382,6 @@ packages:
   /typeforce@1.18.0:
     resolution: {integrity: sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g==}
     dev: false
-
-  /typescript@5.5.3:
-    resolution: {integrity: sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-    dev: true
 
   /typescript@5.6.3:
     resolution: {integrity: sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,7 +63,7 @@ importers:
         version: 3.0.7
       '@layerzerolabs/tsup-config-next':
         specifier: ~3.0.7
-        version: 3.0.7(ts-node@10.9.2)(typescript@5.5.3)
+        version: 3.0.7(ts-node@10.9.2)(typescript@5.6.3)
       '@layerzerolabs/typescript-config-next':
         specifier: ~3.0.7
         version: 3.0.7
@@ -75,10 +75,10 @@ importers:
         version: 18.19.31
       tsup:
         specifier: ^8.0.1
-        version: 8.0.2(ts-node@10.9.2)(typescript@5.5.3)
+        version: 8.0.2(ts-node@10.9.2)(typescript@5.6.3)
       typescript:
-        specifier: ~5.5.3
-        version: 5.5.3
+        specifier: ~5.6.3
+        version: 5.6.3
 
   packages/stg-devtools-evm-hardhat-v2:
     dependencies:
@@ -341,7 +341,7 @@ importers:
         specifier: ~0.3.22
         version: 0.3.22(@ethersproject/abi@5.7.0)(@ethersproject/abstract-signer@5.7.0)(@ethersproject/contracts@5.7.0)(@ethersproject/providers@5.7.2)(@layerzerolabs/devtools-evm@0.3.13)(@layerzerolabs/devtools@0.3.18)(@layerzerolabs/io-devtools@0.1.11)(@layerzerolabs/lz-definitions@3.0.7)(@nomiclabs/hardhat-ethers@2.2.3)(ethers@5.7.2)(fp-ts@2.16.5)(hardhat-deploy@0.12.2)(hardhat@2.22.3)
       '@layerzerolabs/export-deployments':
-        specifier: ~0.0.11
+        specifier: ~0.0.10
         version: 0.0.11
       '@layerzerolabs/io-devtools':
         specifier: ~0.1.11
@@ -357,7 +357,7 @@ importers:
         version: 0.3.10(@ethersproject/abstract-provider@5.7.0)(@ethersproject/abstract-signer@5.7.0)(@ethersproject/bignumber@5.7.0)(@ethersproject/constants@5.7.0)(@ethersproject/contracts@5.7.0)(@ethersproject/providers@5.7.2)(@layerzerolabs/devtools-evm@0.3.13)(@layerzerolabs/devtools@0.3.18)(@layerzerolabs/io-devtools@0.1.11)(@layerzerolabs/lz-definitions@3.0.7)(@layerzerolabs/protocol-devtools@0.3.9)(zod@3.22.5)
       '@layerzerolabs/solidity-examples':
         specifier: ^1.1.0
-        version: 1.1.0(@ethersproject/hardware-wallets@5.7.0)(@nomiclabs/hardhat-ethers@2.2.3)(@nomiclabs/hardhat-etherscan@3.1.8)(ethers@5.7.2)(ts-node@10.9.2)(typescript@5.5.3)
+        version: 1.1.0(@ethersproject/hardware-wallets@5.7.0)(@nomiclabs/hardhat-ethers@2.2.3)(@nomiclabs/hardhat-etherscan@3.1.8)(ethers@5.7.2)(ts-node@10.9.2)(typescript@5.6.3)
       '@layerzerolabs/test-devtools':
         specifier: ~0.2.6
         version: 0.2.6(@layerzerolabs/lz-definitions@3.0.7)(fast-check@3.22.0)
@@ -369,7 +369,7 @@ importers:
         version: 0.2.37(@ethersproject/abstract-provider@5.7.0)(@ethersproject/abstract-signer@5.7.0)(@ethersproject/bignumber@5.7.0)(@ethersproject/constants@5.7.0)(@ethersproject/providers@5.7.2)(@nomicfoundation/hardhat-ethers@3.0.8)(@nomiclabs/hardhat-ethers@2.2.3)(ethers@5.7.2)(hardhat-deploy@0.12.2)(hardhat@2.22.3)(solidity-bytes-utils@0.8.2)
       '@layerzerolabs/tsup-config-next':
         specifier: ~3.0.7
-        version: 3.0.7(ts-node@10.9.2)(typescript@5.5.3)
+        version: 3.0.7(ts-node@10.9.2)(typescript@5.6.3)
       '@layerzerolabs/typescript-config-next':
         specifier: ~3.0.7
         version: 3.0.7
@@ -411,7 +411,7 @@ importers:
         version: link:../stg-devtools-v2
       '@typechain/ethers-v5':
         specifier: ~11.1.2
-        version: 11.1.2(@ethersproject/abi@5.7.0)(@ethersproject/providers@5.7.2)(ethers@5.7.2)(typechain@8.3.2)(typescript@5.5.3)
+        version: 11.1.2(@ethersproject/abi@5.7.0)(@ethersproject/providers@5.7.2)(ethers@5.7.2)(typechain@8.3.2)(typescript@5.6.3)
       '@typechain/hardhat':
         specifier: ~9.1.0
         version: 9.1.0(@typechain/ethers-v6@0.5.1)(ethers@5.7.2)(hardhat@2.22.3)(typechain@8.3.2)
@@ -444,7 +444,7 @@ importers:
         version: 2.16.5
       hardhat:
         specifier: ^2.16.0
-        version: 2.22.3(ts-node@10.9.2)(typescript@5.5.3)
+        version: 2.22.3(ts-node@10.9.2)(typescript@5.6.3)
       hardhat-contract-sizer:
         specifier: ^2.10.0
         version: 2.10.0(patch_hash=zwub3mpkryg2e2hcmk3oodc75y)(hardhat@2.22.3)
@@ -474,7 +474,7 @@ importers:
         version: 0.8.25
       solhint:
         specifier: ^4.0.0
-        version: 4.5.4(typescript@5.5.3)
+        version: 4.5.4(typescript@5.6.3)
       solidity-coverage:
         specifier: ^0.8.12
         version: 0.8.12(hardhat@2.22.3)
@@ -483,16 +483,16 @@ importers:
         version: github.com/transmissions11/solmate/c892309933b25c03d32b1b0d674df7ae292ba925
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.2(@types/node@18.19.31)(typescript@5.5.3)
+        version: 10.9.2(@types/node@18.19.31)(typescript@5.6.3)
       tsup:
         specifier: ^8.0.1
-        version: 8.0.2(ts-node@10.9.2)(typescript@5.5.3)
+        version: 8.0.2(ts-node@10.9.2)(typescript@5.6.3)
       typechain:
         specifier: ~8.3.2
-        version: 8.3.2(typescript@5.5.3)
+        version: 8.3.2(typescript@5.6.3)
       typescript:
-        specifier: ~5.5.3
-        version: 5.5.3
+        specifier: ~5.6.3
+        version: 5.6.3
       zod:
         specifier: ~3.22.4
         version: 3.22.5
@@ -2404,13 +2404,13 @@ packages:
       '@ethersproject/providers': 5.7.2
       '@layerzerolabs/devtools': 0.3.18(@ethersproject/bytes@5.7.0)(@layerzerolabs/io-devtools@0.1.11)(@layerzerolabs/lz-definitions@2.3.44)(zod@3.22.5)
       '@layerzerolabs/devtools-evm': 0.3.13(@ethersproject/abi@5.7.0)(@ethersproject/abstract-provider@5.7.0)(@ethersproject/abstract-signer@5.7.0)(@ethersproject/address@5.7.0)(@ethersproject/bignumber@5.7.0)(@ethersproject/constants@5.7.0)(@ethersproject/contracts@5.7.0)(@ethersproject/providers@5.7.2)(@layerzerolabs/devtools@0.3.18)(@layerzerolabs/io-devtools@0.1.11)(@layerzerolabs/lz-definitions@2.3.44)(fp-ts@2.16.5)(zod@3.22.5)
-      '@layerzerolabs/export-deployments': 0.0.11
+      '@layerzerolabs/export-deployments': 0.0.10
       '@layerzerolabs/io-devtools': 0.1.11(ink-gradient@2.0.0)(ink-table@3.1.0)(ink@3.2.0)(react@17.0.2)(yoga-layout-prebuilt@1.10.0)(zod@3.22.5)
       '@layerzerolabs/lz-definitions': 2.3.44
       '@nomiclabs/hardhat-ethers': 2.2.3(ethers@5.7.2)(hardhat@2.22.3)
       '@safe-global/protocol-kit': 1.3.0(ethers@5.7.2)
       fp-ts: 2.16.5
-      hardhat: 2.22.3(ts-node@10.9.2)(typescript@5.5.3)
+      hardhat: 2.22.3(ts-node@10.9.2)(typescript@5.6.3)
       hardhat-deploy: 0.12.2
       micro-memoize: 4.1.2
       p-memoize: 4.0.4
@@ -2445,13 +2445,13 @@ packages:
       '@ethersproject/providers': 5.7.2
       '@layerzerolabs/devtools': 0.3.18(@ethersproject/bytes@5.7.0)(@layerzerolabs/io-devtools@0.1.11)(@layerzerolabs/lz-definitions@3.0.7)(zod@3.22.5)
       '@layerzerolabs/devtools-evm': 0.3.13(@ethersproject/abi@5.7.0)(@ethersproject/abstract-provider@5.7.0)(@ethersproject/abstract-signer@5.7.0)(@ethersproject/address@5.7.0)(@ethersproject/bignumber@5.7.0)(@ethersproject/constants@5.7.0)(@ethersproject/contracts@5.7.0)(@ethersproject/providers@5.7.2)(@layerzerolabs/devtools@0.3.18)(@layerzerolabs/io-devtools@0.1.11)(@layerzerolabs/lz-definitions@3.0.7)(fp-ts@2.16.5)(zod@3.22.5)
-      '@layerzerolabs/export-deployments': 0.0.11
+      '@layerzerolabs/export-deployments': 0.0.10
       '@layerzerolabs/io-devtools': 0.1.11(ink-gradient@2.0.0)(ink-table@3.1.0)(ink@3.2.0)(react@17.0.2)(yoga-layout-prebuilt@1.10.0)(zod@3.22.5)
       '@layerzerolabs/lz-definitions': 3.0.7
       '@nomiclabs/hardhat-ethers': 2.2.3(ethers@5.7.2)(hardhat@2.22.3)
       '@safe-global/protocol-kit': 1.3.0(ethers@5.7.2)
       fp-ts: 2.16.5
-      hardhat: 2.22.3(ts-node@10.9.2)(typescript@5.5.3)
+      hardhat: 2.22.3(ts-node@10.9.2)(typescript@5.6.3)
       hardhat-deploy: 0.12.2
       micro-memoize: 4.1.2
       p-memoize: 4.0.4
@@ -2703,14 +2703,14 @@ packages:
     resolution: {integrity: sha512-k8b/BuMBXd3BboT/LAYXVWxzS/l7Oax+31ARziVmGyWPd5Cav+7SYODu8p5WHjLfHG0/6mK6rbh0iL7Bigr/ww==}
     hasBin: true
     dependencies:
-      typescript: 5.5.3
+      typescript: 5.6.3
     dev: true
 
   /@layerzerolabs/export-deployments@0.0.11:
     resolution: {integrity: sha512-VhsAMRLqFJSp6s5WnZzEA0CbIW5TE5OTCRLxY1Hf8yhEAIqzWpUdkqnms65QeRJ+82Mkx6YoR27rBA9v/bgStg==}
     hasBin: true
     dependencies:
-      typescript: 5.5.3
+      typescript: 5.6.3
     dev: true
 
   /@layerzerolabs/io-devtools@0.1.11(ink-gradient@2.0.0)(ink-table@3.1.0)(ink@3.2.0)(react@17.0.2)(yoga-layout-prebuilt@1.10.0)(zod@3.22.5):
@@ -3017,7 +3017,7 @@ packages:
       - typescript
     dev: true
 
-  /@layerzerolabs/solidity-examples@1.1.0(@ethersproject/hardware-wallets@5.7.0)(@nomiclabs/hardhat-ethers@2.2.3)(@nomiclabs/hardhat-etherscan@3.1.8)(ethers@5.7.2)(ts-node@10.9.2)(typescript@5.5.3):
+  /@layerzerolabs/solidity-examples@1.1.0(@ethersproject/hardware-wallets@5.7.0)(@nomiclabs/hardhat-ethers@2.2.3)(@nomiclabs/hardhat-etherscan@3.1.8)(ethers@5.7.2)(ts-node@10.9.2)(typescript@5.6.3):
     resolution: {integrity: sha512-hh9FbWbnt/JEdzfM5s6+lv8DeOwQ+lU6b0cuTyCM0wulerUSqVVkBWfs1CKodwDvvbZdLV5BhTJl9AVflIDOHQ==}
     dependencies:
       '@layerzerolabs/lz-evm-sdk-v1-0.7': 1.5.16
@@ -3027,7 +3027,7 @@ packages:
       '@openzeppelin/hardhat-upgrades': 1.28.0(@nomiclabs/hardhat-ethers@2.2.3)(@nomiclabs/hardhat-etherscan@3.1.8)(ethers@5.7.2)(hardhat@2.22.3)
       dotenv: 10.0.0
       erc721a: 4.3.0
-      hardhat: 2.22.3(ts-node@10.9.2)(typescript@5.5.3)
+      hardhat: 2.22.3(ts-node@10.9.2)(typescript@5.6.3)
       hardhat-contract-sizer: 2.10.0(patch_hash=zwub3mpkryg2e2hcmk3oodc75y)(hardhat@2.22.3)
       hardhat-deploy: 0.10.6(@ethersproject/hardware-wallets@5.7.0)(hardhat@2.22.3)
       hardhat-deploy-ethers: 0.3.0-beta.13(ethers@5.7.2)(hardhat@2.22.3)
@@ -3055,7 +3055,7 @@ packages:
       hardhat: ^2.22.3
       solidity-bytes-utils: ^0.8.2
     dependencies:
-      hardhat: 2.22.3(ts-node@10.9.2)(typescript@5.5.3)
+      hardhat: 2.22.3(ts-node@10.9.2)(typescript@5.6.3)
       solidity-bytes-utils: 0.8.2
     dev: true
 
@@ -3104,7 +3104,7 @@ packages:
       '@nomicfoundation/hardhat-ethers': 3.0.8(ethers@5.7.2)(hardhat@2.22.3)
       ethers: 5.7.2
       fp-ts: 2.16.5
-      hardhat: 2.22.3(ts-node@10.9.2)(typescript@5.5.3)
+      hardhat: 2.22.3(ts-node@10.9.2)(typescript@5.6.3)
       hardhat-deploy: 0.12.2
       ink: 3.2.0(react@17.0.2)
       ink-gradient: 2.0.0(ink@3.2.0)(react@17.0.2)
@@ -3134,6 +3134,22 @@ packages:
       esbuild: 0.19.12
       esbuild-node-externals: 1.15.0(esbuild@0.19.12)
       tsup: 8.0.2(ts-node@10.9.2)(typescript@5.5.3)
+    transitivePeerDependencies:
+      - '@microsoft/api-extractor'
+      - '@swc/core'
+      - postcss
+      - supports-color
+      - ts-node
+      - typescript
+    dev: true
+
+  /@layerzerolabs/tsup-config-next@3.0.7(ts-node@10.9.2)(typescript@5.6.3):
+    resolution: {integrity: sha512-nNhkcmyUce2P8i0i2kd5+PutUeXaHQ9aSkYnBn6W9Z4/yoO/hBsAYMUR3FMu2e17bybDIcqWt2EEQmBb3XDHjw==}
+    dependencies:
+      '@chialab/esbuild-plugin-commonjs': 0.17.2
+      esbuild: 0.19.12
+      esbuild-node-externals: 1.15.0(esbuild@0.19.12)
+      tsup: 8.0.2(ts-node@10.9.2)(typescript@5.6.3)
     transitivePeerDependencies:
       - '@microsoft/api-extractor'
       - '@swc/core'
@@ -3181,10 +3197,10 @@ packages:
       '@layerzerolabs/ua-devtools': 0.3.20(@layerzerolabs/devtools@0.3.18)(@layerzerolabs/io-devtools@0.1.11)(@layerzerolabs/lz-definitions@2.3.44)(@layerzerolabs/lz-v2-utilities@2.3.44)(@layerzerolabs/protocol-devtools@0.3.9)(zod@3.22.5)
       '@layerzerolabs/ua-devtools-evm': 0.3.15(@ethersproject/constants@5.7.0)(@ethersproject/contracts@5.7.0)(@layerzerolabs/devtools-evm@0.3.13)(@layerzerolabs/devtools@0.3.18)(@layerzerolabs/io-devtools@0.1.11)(@layerzerolabs/lz-definitions@2.3.44)(@layerzerolabs/lz-v2-utilities@2.3.44)(@layerzerolabs/protocol-devtools-evm@0.3.10)(@layerzerolabs/protocol-devtools@0.3.9)(@layerzerolabs/ua-devtools@0.3.20)(zod@3.22.5)
       ethers: 5.7.2
-      hardhat: 2.22.3(ts-node@10.9.2)(typescript@5.5.3)
+      hardhat: 2.22.3(ts-node@10.9.2)(typescript@5.6.3)
       hardhat-deploy: 0.12.2
       p-memoize: 4.0.4
-      typescript: 5.5.3
+      typescript: 5.6.3
     dev: true
 
   /@layerzerolabs/ua-devtools-evm-hardhat@0.3.19(@ethersproject/abi@5.7.0)(@ethersproject/bytes@5.7.0)(@ethersproject/contracts@5.7.0)(@ethersproject/hash@5.7.0)(@layerzerolabs/devtools-evm-hardhat@0.3.22)(@layerzerolabs/devtools-evm@0.3.13)(@layerzerolabs/devtools@0.3.18)(@layerzerolabs/io-devtools@0.1.11)(@layerzerolabs/lz-definitions@3.0.7)(@layerzerolabs/protocol-devtools-evm@0.3.10)(@layerzerolabs/protocol-devtools@0.3.9)(@layerzerolabs/ua-devtools-evm@0.3.15)(@layerzerolabs/ua-devtools@0.3.20)(ethers@5.7.2)(hardhat-deploy@0.12.2)(hardhat@2.22.3):
@@ -3221,10 +3237,10 @@ packages:
       '@layerzerolabs/ua-devtools': 0.3.20(@layerzerolabs/devtools@0.3.18)(@layerzerolabs/io-devtools@0.1.11)(@layerzerolabs/lz-definitions@3.0.7)(@layerzerolabs/lz-v2-utilities@3.0.7)(@layerzerolabs/protocol-devtools@0.3.9)(zod@3.22.5)
       '@layerzerolabs/ua-devtools-evm': 0.3.15(@ethersproject/constants@5.7.0)(@ethersproject/contracts@5.7.0)(@layerzerolabs/devtools-evm@0.3.13)(@layerzerolabs/devtools@0.3.18)(@layerzerolabs/io-devtools@0.1.11)(@layerzerolabs/lz-definitions@3.0.7)(@layerzerolabs/lz-v2-utilities@3.0.7)(@layerzerolabs/protocol-devtools-evm@0.3.10)(@layerzerolabs/protocol-devtools@0.3.9)(@layerzerolabs/ua-devtools@0.3.20)(zod@3.22.5)
       ethers: 5.7.2
-      hardhat: 2.22.3(ts-node@10.9.2)(typescript@5.5.3)
+      hardhat: 2.22.3(ts-node@10.9.2)(typescript@5.6.3)
       hardhat-deploy: 0.12.2
       p-memoize: 4.0.4
-      typescript: 5.5.3
+      typescript: 5.6.3
     dev: true
 
   /@layerzerolabs/ua-devtools-evm-hardhat@0.3.19(@ethersproject/abi@5.7.0)(@ethersproject/bytes@5.7.0)(@ethersproject/contracts@5.7.0)(@ethersproject/hash@5.7.0)(@layerzerolabs/devtools-evm-hardhat@0.3.22)(@layerzerolabs/devtools-evm@0.3.13)(@layerzerolabs/devtools@0.3.18)(@layerzerolabs/io-devtools@0.1.11)(@layerzerolabs/lz-definitions@3.0.7)(@layerzerolabs/protocol-devtools-evm@0.3.10)(@layerzerolabs/protocol-devtools@0.3.9)(@layerzerolabs/ua-devtools-evm@0.3.15)(@layerzerolabs/ua-devtools@0.3.20)(ethers@5.7.2)(hardhat-deploy@0.12.4)(hardhat@2.22.14):
@@ -3264,7 +3280,7 @@ packages:
       hardhat: 2.22.14(ts-node@10.9.2)(typescript@5.5.3)
       hardhat-deploy: 0.12.4
       p-memoize: 4.0.4
-      typescript: 5.5.3
+      typescript: 5.6.3
     dev: true
 
   /@layerzerolabs/ua-devtools-evm@0.3.15(@ethersproject/constants@5.7.0)(@ethersproject/contracts@5.7.0)(@layerzerolabs/devtools-evm@0.3.13)(@layerzerolabs/devtools@0.3.18)(@layerzerolabs/io-devtools@0.1.11)(@layerzerolabs/lz-definitions@2.3.44)(@layerzerolabs/lz-v2-utilities@2.3.44)(@layerzerolabs/protocol-devtools-evm@0.3.10)(@layerzerolabs/protocol-devtools@0.3.9)(@layerzerolabs/ua-devtools@0.3.20)(zod@3.22.5):
@@ -3398,7 +3414,7 @@ packages:
     dependencies:
       '@ledgerhq/cryptoassets': 5.53.0
       '@ledgerhq/errors': 5.50.0
-      '@ledgerhq/hw-transport': 5.26.0
+      '@ledgerhq/hw-transport': 5.51.1
       bignumber.js: 9.1.2
       rlp: 2.2.7
     dev: true
@@ -3421,7 +3437,7 @@ packages:
     dependencies:
       '@ledgerhq/devices': 5.51.1
       '@ledgerhq/errors': 5.50.0
-      '@ledgerhq/hw-transport': 5.26.0
+      '@ledgerhq/hw-transport': 5.51.1
       '@ledgerhq/hw-transport-node-hid-noevents': 5.51.1
       '@ledgerhq/logs': 5.50.0
       lodash: 4.17.21
@@ -3435,7 +3451,7 @@ packages:
     deprecated: '@ledgerhq/hw-transport-u2f is deprecated. Please use @ledgerhq/hw-transport-webusb or @ledgerhq/hw-transport-webhid. https://github.com/LedgerHQ/ledgerjs/blob/master/docs/migrate_webusb.md'
     dependencies:
       '@ledgerhq/errors': 5.50.0
-      '@ledgerhq/hw-transport': 5.26.0
+      '@ledgerhq/hw-transport': 5.51.1
       '@ledgerhq/logs': 5.50.0
       u2f-api: 0.2.7
     dev: true
@@ -3474,7 +3490,6 @@ packages:
       '@ledgerhq/errors': 5.50.0
       events: 3.3.0
     dev: true
-    optional: true
 
   /@ledgerhq/hw-transport@6.31.4:
     resolution: {integrity: sha512-6c1ir/cXWJm5dCWdq55NPgCJ3UuKuuxRvf//Xs36Bq9BwkV2YaRQhZITAkads83l07NAdR16hkTWqqpwFMaI6A==}
@@ -3526,7 +3541,7 @@ packages:
       ethers: 5.7.2
       fs-extra: 11.2.0
       glob: 10.3.12
-      hardhat: 2.22.3(ts-node@10.9.2)(typescript@5.5.3)
+      hardhat: 2.22.3(ts-node@10.9.2)(typescript@5.6.3)
       lodash: 4.17.21
       sinon: 17.0.1
       sinon-chai: 3.7.0(chai@4.4.1)(sinon@17.0.1)
@@ -3549,7 +3564,7 @@ packages:
       debug: 4.3.4(supports-color@8.1.1)
       dockerode: 4.0.2
       fs-extra: 11.2.0
-      hardhat: 2.22.3(ts-node@10.9.2)(typescript@5.5.3)
+      hardhat: 2.22.3(ts-node@10.9.2)(typescript@5.6.3)
       proper-lockfile: 4.1.2
       semver: 7.6.0
       sinon: 17.0.1
@@ -3822,7 +3837,7 @@ packages:
       chai-as-promised: 7.1.1(chai@4.4.1)
       deep-eql: 4.1.3
       ethers: 5.7.2
-      hardhat: 2.22.3(ts-node@10.9.2)(typescript@5.5.3)
+      hardhat: 2.22.3(ts-node@10.9.2)(typescript@5.6.3)
       ordinal: 1.0.3
     dev: true
 
@@ -3834,7 +3849,7 @@ packages:
     dependencies:
       debug: 4.3.7(supports-color@8.1.1)
       ethers: 5.7.2
-      hardhat: 2.22.3(ts-node@10.9.2)(typescript@5.5.3)
+      hardhat: 2.22.3(ts-node@10.9.2)(typescript@5.6.3)
       lodash.isequal: 4.5.0
     transitivePeerDependencies:
       - supports-color
@@ -4036,7 +4051,7 @@ packages:
       hardhat: ^2.0.0
     dependencies:
       ethers: 5.7.2
-      hardhat: 2.22.3(ts-node@10.9.2)(typescript@5.5.3)
+      hardhat: 2.22.3(ts-node@10.9.2)(typescript@5.6.3)
     dev: true
 
   /@nomiclabs/hardhat-etherscan@3.1.8(hardhat@2.22.3):
@@ -4051,7 +4066,7 @@ packages:
       chalk: 2.4.2
       debug: 4.3.4(supports-color@8.1.1)
       fs-extra: 7.0.1
-      hardhat: 2.22.3(ts-node@10.9.2)(typescript@5.5.3)
+      hardhat: 2.22.3(ts-node@10.9.2)(typescript@5.6.3)
       lodash: 4.17.21
       semver: 6.3.1
       table: 6.8.2
@@ -4119,7 +4134,7 @@ packages:
       chalk: 4.1.2
       debug: 4.3.4(supports-color@8.1.1)
       ethers: 5.7.2
-      hardhat: 2.22.3(ts-node@10.9.2)(typescript@5.5.3)
+      hardhat: 2.22.3(ts-node@10.9.2)(typescript@5.6.3)
       proper-lockfile: 4.1.2
     transitivePeerDependencies:
       - encoding
@@ -4693,7 +4708,7 @@ packages:
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
     dev: true
 
-  /@typechain/ethers-v5@11.1.2(@ethersproject/abi@5.7.0)(@ethersproject/providers@5.7.2)(ethers@5.7.2)(typechain@8.3.2)(typescript@5.5.3):
+  /@typechain/ethers-v5@11.1.2(@ethersproject/abi@5.7.0)(@ethersproject/providers@5.7.2)(ethers@5.7.2)(typechain@8.3.2)(typescript@5.6.3):
     resolution: {integrity: sha512-ID6pqWkao54EuUQa0P5RgjvfA3MYqxUQKpbGKERbsjBW5Ra7EIXvbMlPp2pcP5IAdUkyMCFYsP2SN5q7mPdLDQ==}
     peerDependencies:
       '@ethersproject/abi': ^5.0.0
@@ -4706,12 +4721,12 @@ packages:
       '@ethersproject/providers': 5.7.2
       ethers: 5.7.2
       lodash: 4.17.21
-      ts-essentials: 7.0.3(typescript@5.5.3)
-      typechain: 8.3.2(typescript@5.5.3)
-      typescript: 5.5.3
+      ts-essentials: 7.0.3(typescript@5.6.3)
+      typechain: 8.3.2(typescript@5.6.3)
+      typescript: 5.6.3
     dev: true
 
-  /@typechain/ethers-v6@0.5.1(ethers@5.7.2)(typechain@8.3.2)(typescript@5.5.3):
+  /@typechain/ethers-v6@0.5.1(ethers@5.7.2)(typechain@8.3.2)(typescript@5.6.3):
     resolution: {integrity: sha512-F+GklO8jBWlsaVV+9oHaPh5NJdd6rAKN4tklGfInX1Q7h0xPgVLP39Jl3eCulPB5qexI71ZFHwbljx4ZXNfouA==}
     peerDependencies:
       ethers: 6.x
@@ -4720,9 +4735,9 @@ packages:
     dependencies:
       ethers: 5.7.2
       lodash: 4.17.21
-      ts-essentials: 7.0.3(typescript@5.5.3)
-      typechain: 8.3.2(typescript@5.5.3)
-      typescript: 5.5.3
+      ts-essentials: 7.0.3(typescript@5.6.3)
+      typechain: 8.3.2(typescript@5.6.3)
+      typescript: 5.6.3
     dev: true
 
   /@typechain/hardhat@9.1.0(@typechain/ethers-v6@0.5.1)(ethers@5.7.2)(hardhat@2.22.3)(typechain@8.3.2):
@@ -4733,11 +4748,11 @@ packages:
       hardhat: ^2.9.9
       typechain: ^8.3.2
     dependencies:
-      '@typechain/ethers-v6': 0.5.1(ethers@5.7.2)(typechain@8.3.2)(typescript@5.5.3)
+      '@typechain/ethers-v6': 0.5.1(ethers@5.7.2)(typechain@8.3.2)(typescript@5.6.3)
       ethers: 5.7.2
       fs-extra: 9.1.0
-      hardhat: 2.22.3(ts-node@10.9.2)(typescript@5.5.3)
-      typechain: 8.3.2(typescript@5.5.3)
+      hardhat: 2.22.3(ts-node@10.9.2)(typescript@5.6.3)
+      typechain: 8.3.2(typescript@5.6.3)
     dev: true
 
   /@types/babel__core@7.20.5:
@@ -5440,11 +5455,6 @@ packages:
 
   /antlr4@4.13.1-patch-1:
     resolution: {integrity: sha512-OjFLWWLzDMV9rdFhpvroCWR4ooktNg9/nvVYSA5z28wuVpU36QUNuioR1XLnQtcjVlf8npjyz593PxnU/f/Cow==}
-    engines: {node: '>=16'}
-    dev: true
-
-  /antlr4@4.13.2:
-    resolution: {integrity: sha512-QiVbZhyy4xAZ17UPEuG3YTOt8ZaoeOR1CvEAqrEsDBsOqINslaB147i9xqljZqoyf5S+EUlGStaj+t22LT9MOg==}
     engines: {node: '>=16'}
     dev: true
 
@@ -6757,22 +6767,6 @@ packages:
     dependencies:
       object-assign: 4.1.1
       vary: 1.1.2
-    dev: true
-
-  /cosmiconfig@8.3.6(typescript@5.5.3):
-    resolution: {integrity: sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      typescript: '>=4.9.5'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      import-fresh: 3.3.0
-      js-yaml: 4.1.0
-      parse-json: 5.2.0
-      path-type: 4.0.0
-      typescript: 5.5.3
     dev: true
 
   /cosmiconfig@8.3.6(typescript@5.6.3):
@@ -9154,7 +9148,7 @@ packages:
     dependencies:
       chalk: 4.1.2
       cli-table3: 0.6.4
-      hardhat: 2.22.3(ts-node@10.9.2)(typescript@5.5.3)
+      hardhat: 2.22.3(ts-node@10.9.2)(typescript@5.6.3)
       strip-ansi: 6.0.1
     dev: true
     patched: true
@@ -9166,7 +9160,7 @@ packages:
       hardhat: ^2.0.0
     dependencies:
       ethers: 5.7.2
-      hardhat: 2.22.3(ts-node@10.9.2)(typescript@5.5.3)
+      hardhat: 2.22.3(ts-node@10.9.2)(typescript@5.6.3)
     dev: true
 
   /hardhat-deploy@0.10.6(@ethersproject/hardware-wallets@5.7.0)(hardhat@2.22.3):
@@ -9195,7 +9189,7 @@ packages:
       enquirer: 2.4.1
       form-data: 4.0.0
       fs-extra: 10.1.0
-      hardhat: 2.22.3(ts-node@10.9.2)(typescript@5.5.3)
+      hardhat: 2.22.3(ts-node@10.9.2)(typescript@5.6.3)
       match-all: 1.2.6
       murmur-128: 0.2.1
       qs: 6.12.1
@@ -9277,7 +9271,7 @@ packages:
     dependencies:
       array-uniq: 1.0.3
       eth-gas-reporter: 0.2.27
-      hardhat: 2.22.3(ts-node@10.9.2)(typescript@5.5.3)
+      hardhat: 2.22.3(ts-node@10.9.2)(typescript@5.6.3)
       sha1: 1.1.1
     transitivePeerDependencies:
       - '@codechecks/client'
@@ -9291,7 +9285,7 @@ packages:
     peerDependencies:
       hardhat: ^2.0.0
     dependencies:
-      hardhat: 2.22.3(ts-node@10.9.2)(typescript@5.5.3)
+      hardhat: 2.22.3(ts-node@10.9.2)(typescript@5.6.3)
     dev: true
 
   /hardhat@2.22.14(ts-node@10.9.2)(typescript@5.5.3):
@@ -9359,7 +9353,7 @@ packages:
       - utf-8-validate
     dev: true
 
-  /hardhat@2.22.3(ts-node@10.9.2)(typescript@5.5.3):
+  /hardhat@2.22.3(ts-node@10.9.2)(typescript@5.6.3):
     resolution: {integrity: sha512-k8JV2ECWNchD6ahkg2BR5wKVxY0OiKot7fuxiIpRK0frRqyOljcR2vKwgWSLw6YIeDcNNA4xybj7Og7NSxr2hA==}
     hasBin: true
     peerDependencies:
@@ -9410,9 +9404,9 @@ packages:
       solc: 0.7.3(debug@4.3.4)
       source-map-support: 0.5.21
       stacktrace-parser: 0.1.10
-      ts-node: 10.9.2(@types/node@18.19.31)(typescript@5.5.3)
+      ts-node: 10.9.2(@types/node@18.19.31)(typescript@5.6.3)
       tsort: 0.0.1
-      typescript: 5.5.3
+      typescript: 5.6.3
       undici: 5.28.4
       uuid: 8.3.2
       ws: 7.5.9
@@ -13242,7 +13236,7 @@ packages:
       - debug
     dev: true
 
-  /solhint@4.5.4(typescript@5.5.3):
+  /solhint@4.5.4(typescript@5.6.3):
     resolution: {integrity: sha512-Cu1XiJXub2q1eCr9kkJ9VPv1sGcmj3V7Zb76B0CoezDOB9bu3DxKIFFH7ggCl9fWpEPD6xBmRLfZrYijkVmujQ==}
     hasBin: true
     dependencies:
@@ -13252,7 +13246,7 @@ packages:
       ast-parents: 0.0.1
       chalk: 4.1.2
       commander: 10.0.1
-      cosmiconfig: 8.3.6(typescript@5.5.3)
+      cosmiconfig: 8.3.6(typescript@5.6.3)
       fast-diff: 1.3.0
       glob: 8.1.0
       ignore: 5.3.1
@@ -13261,34 +13255,6 @@ packages:
       lodash: 4.17.21
       pluralize: 8.0.0
       semver: 7.6.2
-      strip-ansi: 6.0.1
-      table: 6.8.2
-      text-table: 0.2.0
-    optionalDependencies:
-      prettier: 2.8.8
-    transitivePeerDependencies:
-      - typescript
-    dev: true
-
-  /solhint@4.5.4(typescript@5.6.3):
-    resolution: {integrity: sha512-Cu1XiJXub2q1eCr9kkJ9VPv1sGcmj3V7Zb76B0CoezDOB9bu3DxKIFFH7ggCl9fWpEPD6xBmRLfZrYijkVmujQ==}
-    hasBin: true
-    dependencies:
-      '@solidity-parser/parser': 0.18.0
-      ajv: 6.12.6
-      antlr4: 4.13.2
-      ast-parents: 0.0.1
-      chalk: 4.1.2
-      commander: 10.0.1
-      cosmiconfig: 8.3.6(typescript@5.6.3)
-      fast-diff: 1.3.0
-      glob: 8.1.0
-      ignore: 5.3.2
-      js-yaml: 4.1.0
-      latest-version: 7.0.0
-      lodash: 4.17.21
-      pluralize: 8.0.0
-      semver: 7.6.3
       strip-ansi: 6.0.1
       table: 6.8.2
       text-table: 0.2.0
@@ -13325,7 +13291,7 @@ packages:
       ghost-testrpc: 0.0.2
       global-modules: 2.0.0
       globby: 10.0.2
-      hardhat: 2.22.3(ts-node@10.9.2)(typescript@5.5.3)
+      hardhat: 2.22.3(ts-node@10.9.2)(typescript@5.6.3)
       jsonschema: 1.4.1
       lodash: 4.17.21
       mocha: 10.4.0
@@ -14028,12 +13994,12 @@ packages:
       string-format: 2.0.0
     dev: true
 
-  /ts-essentials@7.0.3(typescript@5.5.3):
+  /ts-essentials@7.0.3(typescript@5.6.3):
     resolution: {integrity: sha512-8+gr5+lqO3G84KdiTSMRLtuyJ+nTBVRKuCrK4lidMPdVeEp0uqC875uE5NMcaA7YYMN7XsNiFQuMvasF8HT/xQ==}
     peerDependencies:
       typescript: '>=3.7.0'
     dependencies:
-      typescript: 5.5.3
+      typescript: 5.6.3
     dev: true
 
   /ts-interface-checker@0.1.13:
@@ -14116,6 +14082,37 @@ packages:
       yn: 3.1.1
     dev: true
 
+  /ts-node@10.9.2(@types/node@18.19.31)(typescript@5.6.3):
+    resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 18.19.31
+      acorn: 8.11.3
+      acorn-walk: 8.3.2
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.6.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    dev: true
+
   /tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
     dependencies:
@@ -14177,6 +14174,45 @@ packages:
       sucrase: 3.35.0
       tree-kill: 1.2.2
       typescript: 5.5.3
+    transitivePeerDependencies:
+      - supports-color
+      - ts-node
+    dev: true
+
+  /tsup@8.0.2(ts-node@10.9.2)(typescript@5.6.3):
+    resolution: {integrity: sha512-NY8xtQXdH7hDUAZwcQdY/Vzlw9johQsaqf7iwZ6g1DOUlFYQ5/AtVAjTvihhEyeRlGo4dLRVHtrRaL35M1daqQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7.36.0
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
+    dependencies:
+      bundle-require: 4.0.3(esbuild@0.19.12)
+      cac: 6.7.14
+      chokidar: 3.6.0
+      debug: 4.3.5
+      esbuild: 0.19.12
+      execa: 5.1.1
+      globby: 11.1.0
+      joycon: 3.1.1
+      postcss-load-config: 4.0.2(ts-node@10.9.2)
+      resolve-from: 5.0.0
+      rollup: 4.16.4
+      source-map: 0.8.0-beta.0
+      sucrase: 3.35.0
+      tree-kill: 1.2.2
+      typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
       - ts-node
@@ -14354,7 +14390,7 @@ packages:
     resolution: {integrity: sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==}
     dev: true
 
-  /typechain@8.3.2(typescript@5.5.3):
+  /typechain@8.3.2(typescript@5.6.3):
     resolution: {integrity: sha512-x/sQYr5w9K7yv3es7jo4KTX05CLxOf7TRWwoHlrjRh8H82G64g+k7VuWPJlgMo6qrjfCulOdfBjiaDtmhFYD/Q==}
     hasBin: true
     peerDependencies:
@@ -14369,8 +14405,8 @@ packages:
       mkdirp: 1.0.4
       prettier: 2.8.8
       ts-command-line-args: 2.5.1
-      ts-essentials: 7.0.3(typescript@5.5.3)
-      typescript: 5.5.3
+      ts-essentials: 7.0.3(typescript@5.6.3)
+      typescript: 5.6.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -15016,7 +15052,7 @@ packages:
     resolution: {integrity: sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==}
     requiresBuild: true
     dependencies:
-      string-width: 1.0.2
+      string-width: 4.2.3
     dev: true
     optional: true
 

--- a/turbo.json
+++ b/turbo.json
@@ -22,5 +22,14 @@
       "dependsOn": ["^build", "compile"],
       "outputs": []
     }
-  }
+  },
+  "globalDependencies": [
+    "tsonfig.json",
+    "pnpm-lock.yaml",
+    ".eslintrc.js",
+    ".eslintignore",
+    ".prettierrc.js",
+    ".prettierignore",
+    ".solhintrc.js"
+  ]
 }


### PR DESCRIPTION
### In this PR

- Unfortunately the `as const` feature of `@layerzerolabs/export-deployments` results in `TS7056 The inferred type of this node exceeds the maximum length the compiler will serialize. An explicit type annotation is needed` error. The package has been downgraded
- Since the build did not catch this error, the turbo pipeline has been improved and accounts for the global dependencies now - especially `pnpm-lock.yaml`
- The cleared cache also resulted in a TypeScript error related to the mismatch of the `lz-v2-utilities` package versions. Explicit type annotations were added to the schemas that were producing this error (credit & token messaging schemas)