### PR TITLE
🪲 ETH Is not an OFT on LightLink

### DIFF
--- a/packages/stg-evm-v2/devtools/config/mainnet/01/oft-token.config.ts
+++ b/packages/stg-evm-v2/devtools/config/mainnet/01/oft-token.config.ts
@@ -50,12 +50,6 @@ export default async (): Promise<OmniGraphHardhat<MintableNodeConfig, unknown>> 
     )
     const klaytnETH = onKlaytn({ contractName: klaytnETHContractName })
 
-    const lightlinkETHContractName = getTokenDeployName(
-        TokenName.ETH,
-        getAssetType(EndpointId.LIGHTLINK_V2_MAINNET, TokenName.ETH)
-    )
-    const lightlinkETH = onLightlink({ contractName: lightlinkETHContractName })
-
     const seiETHContractName = getTokenDeployName(TokenName.ETH, getAssetType(EndpointId.SEI_V2_MAINNET, TokenName.ETH))
     const seiETH = onSei({ contractName: seiETHContractName })
 
@@ -166,15 +160,6 @@ export default async (): Promise<OmniGraphHardhat<MintableNodeConfig, unknown>> 
                     owner: getSafeAddress(EndpointId.KLAYTN_V2_MAINNET),
                     minters: {
                         [klaytnAssetAddresses.USDT]: true,
-                    },
-                },
-            },
-            {
-                contract: lightlinkETH,
-                config: {
-                    owner: getSafeAddress(EndpointId.LIGHTLINK_V2_MAINNET),
-                    minters: {
-                        [lightlinkAssetAddresses.ETH]: true,
                     },
                 },
             },


### PR DESCRIPTION
### In this PR

- `ETH` was being configured as an OFT token for LightLink whereas in reality it's a native token