### PR TITLE
Update package.json

### DIFF
--- a/packages/stg-error-parser/package.json
+++ b/packages/stg-error-parser/package.json
@@ -13,7 +13,7 @@
     "dist/**/*"
   ],
   "scripts": {
-    "build": "$npm_execpath tsup --clean",
+    "build": "npm_execpath tsup --clean"
     "clean": "rm -rf dist .turbo",
     "test": "jest"
   },


### PR DESCRIPTION
### The JSON file contains one clear error:

In the `"build"` script, the value `"$npm_execpath tsup --clean"` is incorrect. The `$` symbol should not be used here, as it’s specific to Unix terminals and won’t be interpreted in JSON.