### PR TITLE
🧹 Reference deployed USDT address in stg-definitions-v2

### DIFF
--- a/packages/stg-definitions-v2/package.json
+++ b/packages/stg-definitions-v2/package.json
@@ -25,6 +25,7 @@
     "@layerzerolabs/tsup-config-next": "~3.0.7",
     "@layerzerolabs/typescript-config-next": "~3.0.7",
     "@safe-global/protocol-kit": "^1.3.0",
+    "@stargatefinance/usdt-evm": "^1.0.0",
     "@types/node": "^18.15.11",
     "tsup": "^8.0.1",
     "typescript": "~5.6.3"

--- a/packages/stg-definitions-v2/src/constant.ts
+++ b/packages/stg-definitions-v2/src/constant.ts
@@ -1,4 +1,5 @@
 import { parseEther } from '@ethersproject/units'
+import { contracts } from '@stargatefinance/usdt-evm/deployed'
 
 import { EndpointId } from '@layerzerolabs/lz-definitions'
 
@@ -13,6 +14,8 @@ import {
     TokenMessagingNetworkConfig,
     TokenName,
 } from './types'
+
+const usdtAddressSepolia = contracts.TetherTokenV2.addresses['sepolia-testnet'] // TODO fetch USDT addresses on desired networks in this way
 
 export const DVNS = {
     //
@@ -340,6 +343,13 @@ export const ASSETS: Record<TokenName, AssetConfig> = {
             [EndpointId.SEPOLIA_V2_TESTNET]: {
                 type: StargateType.Pool,
             },
+            /**
+             * TODO configure USDT address for relevant network
+               [EndpointId.SEPOLIA_V2_TESTNET]: {
+                    address: usdtAddressSepolia,
+                    type: StargateType.Pool,
+                },
+             */
 
             //
             // SANDBOX

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,6 +73,9 @@ importers:
       '@safe-global/protocol-kit':
         specifier: ^1.3.0
         version: 1.3.0(ethers@5.7.2)
+      '@stargatefinance/usdt-evm':
+        specifier: ^1.0.0
+        version: link:../stg-evm-usdt-v2
       '@types/node':
         specifier: ^18.15.11
         version: 18.19.31
@@ -8914,7 +8917,7 @@ packages:
       solc: 0.8.26(debug@4.3.7)
       source-map-support: 0.5.21
       stacktrace-parser: 0.1.10
-      ts-node: 10.9.2(@types/node@18.19.59)(typescript@5.6.3)
+      ts-node: 10.9.2(@types/node@18.19.31)(typescript@5.6.3)
       tsort: 0.0.1
       typescript: 5.6.3
       undici: 5.28.4
@@ -11505,7 +11508,7 @@ packages:
         optional: true
     dependencies:
       lilconfig: 3.0.0
-      ts-node: 10.9.2(@types/node@18.19.59)(typescript@5.6.3)
+      ts-node: 10.9.2(@types/node@18.19.31)(typescript@5.6.3)
       yaml: 2.3.4
     dev: true
 


### PR DESCRIPTION
## In this PR:

Reference deployed USDT address from `stg-evm-usdt-evm-v2` in `stg-definitions-v2`. Also added TODO comments on how to fetch USDT address for other networks