### PR TITLE
🧹 Validate RPCs before configuring testnets and mainnets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,8 @@ CONFIGURE_TREASURER=$(HARDHAT) stg:wire::treasurer
 CONFIGURE_MINT_ALLOWANCE=$(HARDHAT) stg:set::mint-allowance
 CONFIGURE_LIQUIDITY=$(HARDHAT) stg:add::liquidity
 
+VALIDATE_RPCS = $(HARDHAT) lz:healthcheck:validate:rpcs
+
 # Arguments to be always passed to hardhat lz:deploy devtools command
 # 
 # These allow consumers of this script to pass flags like --ci or --reset
@@ -168,6 +170,9 @@ deploy-testnet: build deploy
 
 configure-testnet: CONFIG_BASE_PATH=./devtools/config/testnet
 configure-testnet:
+	# Validate RPCs
+	$(VALIDATE_RPCS) --config ./hardhat.config.ts --timeout 5000
+
 	# Configure the OFTs
 	$(CONFIGURE_OFT) $(CONFIGURE_ARGS_COMMON) --oapp-config $(CONFIG_BASE_PATH)/oft-token.config.ts --signer deployer
 
@@ -240,6 +245,9 @@ deploy-mainnet: build deploy
 
 preconfigure-mainnet: CONFIG_BASE_PATH=./devtools/config/mainnet/01
 preconfigure-mainnet:
+	# Validate RPCs
+	$(VALIDATE_RPCS) --config ./hardhat.config.ts
+
 	# Configure the OFTs
 	$(CONFIGURE_OFT) $(CONFIGURE_ARGS_COMMON) --oapp-config $(CONFIG_BASE_PATH)/oft-token.config.ts --signer deployer
 

--- a/packages/stg-evm-v2/hardhat.config.ts
+++ b/packages/stg-evm-v2/hardhat.config.ts
@@ -130,7 +130,7 @@ const networks: NetworksUserConfig = {
     },
     'klaytn-testnet': {
         eid: EndpointId.KLAYTN_V2_TESTNET,
-        url: process.env.RPC_URL_KLAYTN_TESTNET || 'https://public-en.kairos.node.kaia.io',
+        url: process.env.RPC_URL_KLAYTN_TESTNET || 'https://kaia-kairos.blockpi.network/v1/rpc/public',
         accounts: testnetAccounts,
     },
     'optsep-testnet': {
@@ -411,7 +411,7 @@ const networks: NetworksUserConfig = {
     },
     'zksync-mainnet': {
         eid: EndpointId.ZKSYNC_V2_MAINNET,
-        url: process.env.RPC_URL_ZKSYNC_MAINNET || 'https://zksync.drpc.org',
+        url: process.env.RPC_URL_ZKSYNC_MAINNET || 'https://mainnet.era.zksync.io',
         accounts: mainnetAccounts,
         safeConfig: getSafeConfig(EndpointId.ZKSYNC_V2_MAINNET),
         timeout: DEFAULT_NETWORK_TIMEOUT,


### PR DESCRIPTION
## In this PR:
- Updated `Makefile` to call existing `lz:healthcheck:validate:rpcs` task before proceeding with configurations
- Note that this task will fail for sandbox rpcs if they are not running on localhost
- Updated klaytn testnet and zksync mainnet rpcs since they were not passing validation

**Example of what successful RPC validation looks like:**

```
ravina@Ravinas-MacBook-Pro stargate-v2 % LZ_ENABLE_EXPERIMENTAL_PARALLEL_EXECUTION=1 LZ_ENABLE_EXPERIMENTAL_BATCHED_WAIT=1 LZ_EXPERIMENTAL_WITH_SIMULATION=1 make configure-testnet CONFIGURE_ARGS_COMMON=--ci
# Validate RPCs
pnpm --filter @stargatefinance/stg-evm-v2 run hardhat lz:healthcheck:validate:rpcs --config ./hardhat.config.ts --timeout 5000

> @stargatefinance/stg-evm-v2@1.1.3 hardhat /Users/ravina/github.com/stargate-v2-fixed/stargate-v2/packages/stg-evm-v2
> hardhat "lz:healthcheck:validate:rpcs" "--config" "./hardhat.config.ts" "--timeout" "5000"

warn:    [simulation] 
warn:    [simulation] The experimental simulation mode is enabled
warn:    [simulation] This feature is still in developer preview
warn:    [simulation] 
warn:    [simulation] !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
warn:    [simulation] !!! ONLY USE AT YOUR OWN RISK !!!
warn:    [simulation] !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
warn:    [simulation] 
warn:    [simulation] The networks in your hardhat config will be forked
warn:    [simulation] 
warn:    [simulation] The new network configuration is as follows:
warn:    [simulation] 
warn:    [simulation] Network localhost -> http://localhost:8545/localhost
warn:    [simulation] Network arbsep-testnet -> http://localhost:8545/arbsep-testnet
warn:    [simulation] Network bsc-testnet -> http://localhost:8545/bsc-testnet
warn:    [simulation] Network klaytn-testnet -> http://localhost:8545/klaytn-testnet
warn:    [simulation] Network optsep-testnet -> http://localhost:8545/optsep-testnet
warn:    [simulation] Network sepolia-testnet -> http://localhost:8545/sepolia-testnet
warn:    [simulation] Network arbitrum-mainnet -> http://localhost:8545/arbitrum-mainnet
warn:    [simulation] Network astar-mainnet -> http://localhost:8545/astar-mainnet
warn:    [simulation] Network aurora-mainnet -> http://localhost:8545/aurora-mainnet
warn:    [simulation] Network avalanche-mainnet -> http://localhost:8545/avalanche-mainnet
warn:    [simulation] Network base-mainnet -> http://localhost:8545/base-mainnet
warn:    [simulation] Network blast-mainnet -> http://localhost:8545/blast-mainnet
warn:    [simulation] Network bsc-mainnet -> http://localhost:8545/bsc-mainnet
warn:    [simulation] Network coredao-mainnet -> http://localhost:8545/coredao-mainnet
warn:    [simulation] Network ebi-mainnet -> http://localhost:8545/ebi-mainnet
warn:    [simulation] Network ethereum-mainnet -> http://localhost:8545/ethereum-mainnet
warn:    [simulation] Network etherlink-mainnet -> http://localhost:8545/etherlink-mainnet
warn:    [simulation] Network fantom-mainnet -> http://localhost:8545/fantom-mainnet
warn:    [simulation] Network flare-mainnet -> http://localhost:8545/flare-mainnet
warn:    [simulation] Network fraxtal-mainnet -> http://localhost:8545/fraxtal-mainnet
warn:    [simulation] Network gravity-mainnet -> http://localhost:8545/gravity-mainnet
warn:    [simulation] Network iota-mainnet -> http://localhost:8545/iota-mainnet
warn:    [simulation] Network kava-mainnet -> http://localhost:8545/kava-mainnet
warn:    [simulation] Network klaytn-mainnet -> http://localhost:8545/klaytn-mainnet
warn:    [simulation] Network lightlink-mainnet -> http://localhost:8545/lightlink-mainnet
warn:    [simulation] Network manta-mainnet -> http://localhost:8545/manta-mainnet
warn:    [simulation] Network mantle-mainnet -> http://localhost:8545/mantle-mainnet
warn:    [simulation] Network metis-mainnet -> http://localhost:8545/metis-mainnet
warn:    [simulation] Network mode-mainnet -> http://localhost:8545/mode-mainnet
warn:    [simulation] Network moonbeam-mainnet -> http://localhost:8545/moonbeam-mainnet
warn:    [simulation] Network moonriver-mainnet -> http://localhost:8545/moonriver-mainnet
warn:    [simulation] Network opbnb-mainnet -> http://localhost:8545/opbnb-mainnet
warn:    [simulation] Network optimism-mainnet -> http://localhost:8545/optimism-mainnet
warn:    [simulation] Network polygon-mainnet -> http://localhost:8545/polygon-mainnet
warn:    [simulation] Network rarible-mainnet -> http://localhost:8545/rarible-mainnet
warn:    [simulation] Network scroll-mainnet -> http://localhost:8545/scroll-mainnet
warn:    [simulation] Network sei-mainnet -> http://localhost:8545/sei-mainnet
warn:    [simulation] Network shimmer-mainnet -> http://localhost:8545/shimmer-mainnet
warn:    [simulation] Network taiko-mainnet -> http://localhost:8545/taiko-mainnet
warn:    [simulation] Network xchain-mainnet -> http://localhost:8545/xchain-mainnet
warn:    [simulation] Network zkatana-mainnet -> http://localhost:8545/zkatana-mainnet
warn:    [simulation] Network zkconsensys-mainnet -> http://localhost:8545/zkconsensys-mainnet
warn:    [simulation] Network zkpolygon-mainnet -> http://localhost:8545/zkpolygon-mainnet
warn:    [simulation] Network zksync-mainnet -> http://localhost:8545/zksync-mainnet
warn:    [simulation] 






                                                                              **********                                                                                                                  
                                                                            **************                                                                                                                
                                                                          ******************                                                                                                              
                                                                         ********************                                                                                                             
                                                                         *********  *********                                                                                                             
                                                                         *********  *********          ****                                                 ***********                                   
                                                                         *********  *********          ****                                                 ***********                                   
                                                                            ******  *********          ****        *************    ****  ******   *******       ****    ******    *** **   ******        
                                                                          ********  *********          ****      *********** ****  **** ********** *******      ****   *********** ****** **********      
                                                                         *********  ********           ****     ****    ****  ******** ***   ***** ****        ****   ****   ***** ****  ****    ****     
                                                                         *********  ******             ****     ****    ****   ******* ********    ****      *****    *********    ***   ****    ****     
                                                                         *********  *********          ********* ***********   ******   ********** ****     ********************** ***    **********  ****
                                                                         *********  *********          *********  **********    ****     ********  ****     ***********  ********  ***      *******   ****
                                                                         *********  *********                                 *****                                                                       
                                                                         ********************                                 ****                                                                        
                                                                          ******************                                                                                                              
                                                                           ****************                                                                                                               
                                                                              **********                                                                                                                  







info:    ========== Validating RPC URLs for networks: hardhat,localhost,arbsep-testnet,bsc-testnet,klaytn-testnet,optsep-testnet,sepolia-testnet,arbitrum-mainnet,astar-mainnet,aurora-mainnet,avalanche-mainnet,base-mainnet,blast-mainnet,bsc-mainnet,coredao-mainnet,ebi-mainnet,ethereum-mainnet,etherlink-mainnet,fantom-mainnet,flare-mainnet,fraxtal-mainnet,gravity-mainnet,iota-mainnet,kava-mainnet,klaytn-mainnet,lightlink-mainnet,manta-mainnet,mantle-mainnet,metis-mainnet,mode-mainnet,moonbeam-mainnet,moonriver-mainnet,opbnb-mainnet,optimism-mainnet,polygon-mainnet,rarible-mainnet,scroll-mainnet,sei-mainnet,shimmer-mainnet,taiko-mainnet,xchain-mainnet,zkatana-mainnet,zkconsensys-mainnet,zkpolygon-mainnet,zksync-mainnet
info:    No eid found for network hardhat, skipping
info:    No eid found for network localhost, skipping
info:    ✓ ========== All RPC URLs are valid!
# Configure the OFTs
pnpm --filter @stargatefinance/stg-evm-v2 run hardhat stg:wire::oft --ci --oapp-config ./devtools/config/testnet/oft-token.config.ts --signer deployer

> @stargatefinance/stg-evm-v2@1.1.3 hardhat /Users/ravina/github.com/stargate-v2-fixed/stargate-v2/packages/stg-evm-v2
> hardhat "stg:wire::oft" "--ci" "--oapp-config" "./devtools/config/testnet/oft-token.config.ts" "--signer" "deployer"

^C
ravina@Ravinas-MacBook-Pro stargate-v2 % 
```

**Example of what unsuccessful RPC validation looks like:**

```

info:    ========== Validating RPC URLs for networks: hardhat,localhost,arbsep-testnet,bsc-testnet,klaytn-testnet,optsep-testnet,sepolia-testnet,arbitrum-mainnet,astar-mainnet,aurora-mainnet,avalanche-mainnet,base-mainnet,blast-mainnet,bsc-mainnet,coredao-mainnet,ebi-mainnet,ethereum-mainnet,etherlink-mainnet,fantom-mainnet,flare-mainnet,fraxtal-mainnet,gravity-mainnet,iota-mainnet,kava-mainnet,klaytn-mainnet,lightlink-mainnet,manta-mainnet,mantle-mainnet,metis-mainnet,mode-mainnet,moonbeam-mainnet,moonriver-mainnet,opbnb-mainnet,optimism-mainnet,polygon-mainnet,rarible-mainnet,scroll-mainnet,sei-mainnet,shimmer-mainnet,taiko-mainnet,xchain-mainnet,zkatana-mainnet,zkconsensys-mainnet,zkpolygon-mainnet,zksync-mainnet
info:    No eid found for network hardhat, skipping
info:    No eid found for network localhost, skipping
error:   ⤫ ========== RPC URL validation failed for network(s): klaytn-testnet
# Configure the OFTs
```