### PR TITLE
🧹 Drop USDT from Peaq mainnet config

### DIFF
--- a/packages/stg-evm-v2/devtools/config/mainnet/01/asset.usdt.config.ts
+++ b/packages/stg-evm-v2/devtools/config/mainnet/01/asset.usdt.config.ts
@@ -33,7 +33,6 @@ export default async (): Promise<OmniGraphHardhat<AssetNodeConfig, AssetEdgeConf
     const mantlePoint = getAssetPoint(EndpointId.MANTLE_V2_MAINNET)
     const metisPoint = getAssetPoint(EndpointId.METIS_V2_MAINNET)
     const optPoint = getAssetPoint(EndpointId.OPTIMISM_V2_MAINNET)
-    const peaqPoint = getAssetPoint(EndpointId.PEAQ_V2_MAINNET)
     const polygonPoint = getAssetPoint(EndpointId.POLYGON_V2_MAINNET)
     const rariblePoint = getAssetPoint(EndpointId.RARIBLE_V2_MAINNET)
     const seiPoint = getAssetPoint(EndpointId.SEI_V2_MAINNET)
@@ -55,7 +54,6 @@ export default async (): Promise<OmniGraphHardhat<AssetNodeConfig, AssetEdgeConf
     const mantleContract = await getAssetNode(mantlePoint)
     const metisContract = await getAssetNode(metisPoint)
     const optContract = await getAssetNode(optPoint)
-    const peaqContract = await getAssetNode(peaqPoint)
     const polygonContract = await getAssetNode(polygonPoint)
     const raribleContract = await getAssetNode(rariblePoint)
     const seiContract = await getAssetNode(seiPoint)
@@ -78,7 +76,6 @@ export default async (): Promise<OmniGraphHardhat<AssetNodeConfig, AssetEdgeConf
             mantleContract,
             metisContract,
             optContract,
-            peaqContract,
             polygonContract,
             raribleContract,
             seiContract,
@@ -100,7 +97,6 @@ export default async (): Promise<OmniGraphHardhat<AssetNodeConfig, AssetEdgeConf
             mantlePoint,
             metisPoint,
             optPoint,
-            peaqPoint,
             polygonPoint,
             rariblePoint,
             seiPoint,

--- a/packages/stg-evm-v2/devtools/config/mainnet/01/oft-token.config.ts
+++ b/packages/stg-evm-v2/devtools/config/mainnet/01/oft-token.config.ts
@@ -23,7 +23,6 @@ export default async (): Promise<OmniGraphHardhat<MintableNodeConfig, unknown>> 
     const iotaUSDT = onIota(usdtContractTemplate)
     const klaytnUSDT = onKlaytn(usdtContractTemplate)
     const lightlinkUSDT = onLightlink(usdtContractTemplate)
-    const peaqUSDT = onPeaq(usdtContractTemplate)
     const raribleUSDT = onRarible(usdtContractTemplate)
     const taikoUSDT = onTaiko(usdtContractTemplate)
 
@@ -189,15 +188,6 @@ export default async (): Promise<OmniGraphHardhat<MintableNodeConfig, unknown>> 
                     owner: getSafeAddress(EndpointId.PEAQ_V2_MAINNET),
                     minters: {
                         [peaqAssetAddresses.ETH]: true,
-                    },
-                },
-            },
-            {
-                contract: peaqUSDT,
-                config: {
-                    owner: getSafeAddress(EndpointId.PEAQ_V2_MAINNET),
-                    minters: {
-                        [peaqAssetAddresses.USDT]: true,
                     },
                 },
             },

--- a/packages/stg-evm-v2/devtools/config/mainnet/01/shared.ts
+++ b/packages/stg-evm-v2/devtools/config/mainnet/01/shared.ts
@@ -84,7 +84,6 @@ export const getMessagingAssetConfig = async (getEnvironment = createGetHreByEid
     const peaqAssetAddresses = await getAssetAddresses(EndpointId.PEAQ_V2_MAINNET, [
         TokenName.ETH,
         TokenName.USDC,
-        TokenName.USDT,
     ] as const)
     const polygonAssetAddresses = await getAssetAddresses(EndpointId.POLYGON_V2_MAINNET, [
         TokenName.USDC,
@@ -194,7 +193,6 @@ export const getMessagingAssetConfig = async (getEnvironment = createGetHreByEid
         [EndpointId.PEAQ_V2_MAINNET]: {
             [peaqAssetAddresses.ETH]: ASSETS[TokenName.ETH].assetId,
             [peaqAssetAddresses.USDC]: ASSETS[TokenName.USDC].assetId,
-            [peaqAssetAddresses.USDT]: ASSETS[TokenName.USDT].assetId,
         },
         [EndpointId.POLYGON_V2_MAINNET]: {
             [polygonAssetAddresses.USDC]: ASSETS[TokenName.USDC].assetId,

--- a/packages/stg-evm-v2/devtools/config/mainnet/01/treasurer.config.ts
+++ b/packages/stg-evm-v2/devtools/config/mainnet/01/treasurer.config.ts
@@ -144,7 +144,6 @@ export default async (): Promise<OmniGraphHardhat<TreasurerNodeConfig, unknown>>
     const peaqAssetAddresses = await getAssetAddresses(EndpointId.PEAQ_V2_MAINNET, [
         TokenName.ETH,
         TokenName.USDC,
-        TokenName.USDT,
     ] as const)
     const polygonAssetAddresses = await getAssetAddresses(EndpointId.POLYGON_V2_MAINNET, [
         TokenName.USDC,
@@ -379,7 +378,6 @@ export default async (): Promise<OmniGraphHardhat<TreasurerNodeConfig, unknown>>
                     assets: {
                         [peaqAssetAddresses.ETH]: true,
                         [peaqAssetAddresses.USDC]: true,
-                        [peaqAssetAddresses.USDT]: true,
                     },
                 },
             },


### PR DESCRIPTION
### In this PR

- Due to token incompatibility, USDT is temporarily dropped from Peaq config