### PR TITLE
🧹 Add transferTokenOwnership function to StargateOFT

### DIFF
--- a/packages/stg-evm-v2/src/StargateOFT.sol
+++ b/packages/stg-evm-v2/src/StargateOFT.sol
@@ -22,6 +22,12 @@ contract StargateOFT is StargateBase {
         address _owner
     ) StargateBase(_token, IERC20Metadata(_token).decimals(), _sharedDecimals, _endpoint, _owner) {}
 
+    /// @notice Transfer ownership of the token to a new owner.
+    /// @param _newOwner The account to set as owner
+    function transferTokenOwnership(address _newOwner) external onlyOwner {
+        IERC20Minter(token).transferOwnership(_newOwner); // TODO how do i know this is the correct function to call -- where exactly does this lead after the IERC20Minter?
+    }
+
     /// @notice Burn tokens to represent their removal from the local chain
     /// @param _from The address to burn tokens from
     /// @param _amount How many tokens to burn in LD

--- a/packages/stg-evm-v2/src/StargateOFT.sol
+++ b/packages/stg-evm-v2/src/StargateOFT.sol
@@ -12,10 +12,6 @@ import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 /// @title A Stargate contract representing an OFT. This contract will burn OFTs when sending tokens
 /// @title to other chains and mint tokens when receiving them from other chains.
 contract StargateOFT is StargateBase {
-    // error TransferTokenOwnershipFailed();
-
-    // event TokenOwnershipTransferred(address token, address newOwner);
-
     /// @notice Create a StargateOFT contract administering an OFT.
     /// @param _token The OFT to administer
     /// @param _sharedDecimals The minimum number of decimals used to represent value in this OFT

--- a/packages/stg-evm-v2/src/StargateOFT.sol
+++ b/packages/stg-evm-v2/src/StargateOFT.sol
@@ -7,12 +7,14 @@ import { StargateType } from "./interfaces/IStargate.sol";
 import { IERC20Minter } from "./interfaces/IERC20Minter.sol";
 import { StargateBase, FeeParams } from "./StargateBase.sol";
 
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+
 /// @title A Stargate contract representing an OFT. This contract will burn OFTs when sending tokens
 /// @title to other chains and mint tokens when receiving them from other chains.
 contract StargateOFT is StargateBase {
-    error TransferTokenOwnershipFailed();
+    // error TransferTokenOwnershipFailed();
 
-    event TokenOwnershipTransferred(address token, address newOwner);
+    // event TokenOwnershipTransferred(address token, address newOwner);
 
     /// @notice Create a StargateOFT contract administering an OFT.
     /// @param _token The OFT to administer
@@ -29,11 +31,7 @@ contract StargateOFT is StargateBase {
     /// @notice Transfer ownership of the token to a new owner.
     /// @param _newOwner The account to set as owner
     function transferTokenOwnership(address _newOwner) external onlyOwner {
-        try IERC20Minter(token).transferOwnership(_newOwner) {
-            emit TokenOwnershipTransferred(token, _newOwner);
-        } catch {
-            revert TransferTokenOwnershipFailed();
-        }
+        Ownable(token).transferOwnership(_newOwner);
     }
 
     /// @notice Burn tokens to represent their removal from the local chain

--- a/packages/stg-evm-v2/src/StargateOFT.sol
+++ b/packages/stg-evm-v2/src/StargateOFT.sol
@@ -10,6 +10,10 @@ import { StargateBase, FeeParams } from "./StargateBase.sol";
 /// @title A Stargate contract representing an OFT. This contract will burn OFTs when sending tokens
 /// @title to other chains and mint tokens when receiving them from other chains.
 contract StargateOFT is StargateBase {
+    error TransferTokenOwnershipFailed();
+
+    event TokenOwnershipTransferred(address token, address newOwner);
+
     /// @notice Create a StargateOFT contract administering an OFT.
     /// @param _token The OFT to administer
     /// @param _sharedDecimals The minimum number of decimals used to represent value in this OFT
@@ -25,7 +29,11 @@ contract StargateOFT is StargateBase {
     /// @notice Transfer ownership of the token to a new owner.
     /// @param _newOwner The account to set as owner
     function transferTokenOwnership(address _newOwner) external onlyOwner {
-        IERC20Minter(token).transferOwnership(_newOwner); // TODO how do i know this is the correct function to call -- where exactly does this lead after the IERC20Minter?
+        try IERC20Minter(token).transferOwnership(_newOwner) {
+            emit TokenOwnershipTransferred(token, _newOwner);
+        } catch {
+            revert TransferTokenOwnershipFailed();
+        }
     }
 
     /// @notice Burn tokens to represent their removal from the local chain

--- a/packages/stg-evm-v2/src/interfaces/IERC20Minter.sol
+++ b/packages/stg-evm-v2/src/interfaces/IERC20Minter.sol
@@ -13,8 +13,4 @@ interface IERC20Minter {
     /// @param _from The account to burn tokens from
     /// @param _amount How many tokens to burn
     function burnFrom(address _from, uint256 _amount) external;
-
-    /// @notice Transfer ownership of the token to a new owner.
-    /// @param _newOwner The account to set as owner
-    function transferOwnership(address _newOwner) external;
 }

--- a/packages/stg-evm-v2/src/interfaces/IERC20Minter.sol
+++ b/packages/stg-evm-v2/src/interfaces/IERC20Minter.sol
@@ -13,4 +13,8 @@ interface IERC20Minter {
     /// @param _from The account to burn tokens from
     /// @param _amount How many tokens to burn
     function burnFrom(address _from, uint256 _amount) external;
+
+    /// @notice Transfer ownership of the token to a new owner.
+    /// @param _newOwner The account to set as owner
+    function transferOwnership(address _newOwner) external;
 }


### PR DESCRIPTION
The Tether USDT contracts require the owner of the token contract to be the only minter allowed. For stargate, this means that the `StargateOFTUSDT` contract will be the owner and minter of the USDT token. 

However the `StargateOFTUSDT` contract currently does not support all `onlyOwner` functions of the USDT token contract -- it only supports mint and burn. Therefore, we will implement a `transferTokenOwnership` function to allow the option of temporarily transferring ownership if the unsupported `onlyOwner` functions on the USDT token contract are ever needed.

This is the extent of the change -- we do not need to worry about the eventual transfer of ownership to Tether which will revoke `StargateOFTUSDT`'s minting privileges because at that point, `StargateOFTUSDT` will be deprecated anyway in favour of `StargatePoolUSDT`. 