### PR TITLE
🧹 Updating external USDT deployment process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -185,6 +185,9 @@ configure-testnet:
 	# Transfer ownership
 	$(TRANSFER_OWNERSHIP) $(CONFIGURE_ARGS_COMMON) --oapp-config $(CONFIG_BASE_PATH)/usdc-token.config.ts --signer deployer
 
+	# Transfer USDT ownership
+	$(TRANSFER_OWNERSHIP) $(CONFIGURE_ARGS_COMMON) --oapp-config $(CONFIG_BASE_PATH)/usdt-token.config.ts --signer deployer
+
 	# Configure the assets
 	$(CONFIGURE_ASSET) $(CONFIGURE_ARGS_COMMON) --oapp-config $(CONFIG_BASE_PATH)/asset.usdc.config.ts --signer deployer
 	$(CONFIGURE_ASSET) $(CONFIGURE_ARGS_COMMON) --oapp-config $(CONFIG_BASE_PATH)/asset.usdt.config.ts --signer deployer
@@ -304,6 +307,9 @@ transfer-mainnet:
 
 	# Transfer USDC ownership
 	$(TRANSFER_OWNERSHIP) $(CONFIGURE_ARGS_COMMON) --oapp-config $(CONFIG_BASE_PATH)/usdc-token.config.ts --signer deployer
+
+	# Transfer USDT ownership
+	$(TRANSFER_OWNERSHIP) $(CONFIGURE_ARGS_COMMON) --oapp-config $(CONFIG_BASE_PATH)/usdt-token.config.ts --signer deployer
 
 	# The assets
 	$(TRANSFER_OWNERSHIP) $(CONFIGURE_ARGS_COMMON) --oapp-config $(CONFIG_BASE_PATH)/asset.eth.config.ts --signer deployer

--- a/packages/stg-definitions-v2/src/constant.ts
+++ b/packages/stg-definitions-v2/src/constant.ts
@@ -260,6 +260,15 @@ export const ASSETS: Record<TokenName, AssetConfig> = {
             //
             // MAINNET
             //
+
+            /*
+                EXAMPLE:
+                    [EndpointId.ABC_V2_MAINNET]: {
+                        type: StargateType.Oft,
+                        address: '0xABC123',
+                    },
+             */
+
             [EndpointId.ARBITRUM_V2_MAINNET]: {
                 type: StargateType.Pool,
                 address: '0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9',

--- a/packages/stg-evm-v2/devtools/config/mainnet/01/usdt-token.config.ts
+++ b/packages/stg-evm-v2/devtools/config/mainnet/01/usdt-token.config.ts
@@ -1,0 +1,46 @@
+import assert from 'assert'
+
+import { TokenName } from '@stargatefinance/stg-definitions-v2'
+import { USDCNodeConfig } from '@stargatefinance/stg-devtools-v2'
+
+import { OmniGraphHardhat, createContractFactory, createGetHreByEid } from '@layerzerolabs/devtools-evm-hardhat'
+import { EndpointId } from '@layerzerolabs/lz-definitions'
+
+import { createGetAssetAddresses, getAssetNetworkConfig } from '../../../../ts-src/utils/util'
+import { onPeaq } from '../utils'
+
+const fiatContract = { contractName: 'FiatTokenV2_2' }
+
+// For external USDT deployments
+const usdtPeaqAsset = getAssetNetworkConfig(EndpointId.PEAQ_V2_MAINNET, TokenName.USDT)
+assert(usdtPeaqAsset.address != null, `External USDT address not found for PEAQ`)
+
+// TODO change USDCNodeConfig to USDTNodeConfig, but that does not yet exist
+export default async (): Promise<OmniGraphHardhat<USDCNodeConfig, unknown>> => {
+    // First let's create the HardhatRuntimeEnvironment objects for all networks
+    const getEnvironment = createGetHreByEid()
+    const contractFactory = createContractFactory(getEnvironment)
+
+    const peaqUSDTProxy = await contractFactory(
+        onPeaq({ contractName: 'FiatTokenProxy', address: usdtPeaqAsset.address })
+    )
+
+    const peaqUSDT = onPeaq({ ...fiatContract, address: peaqUSDTProxy.contract.address })
+
+    // Now we collect the address of the deployed assets(StargateOft.sol etc.)
+    const usdtAssets = [TokenName.USDT] as const
+    const getAssetAddresses = createGetAssetAddresses(getEnvironment)
+    const peaqAssetAddresses = await getAssetAddresses(EndpointId.PEAQ_V2_MAINNET, usdtAssets)
+
+    return {
+        contracts: [
+            {
+                contract: peaqUSDT,
+                config: {
+                    owner: peaqAssetAddresses.USDT,
+                },
+            },
+        ],
+        connections: [],
+    }
+}

--- a/packages/stg-evm-v2/devtools/config/testnet/usdt-token.config.ts
+++ b/packages/stg-evm-v2/devtools/config/testnet/usdt-token.config.ts
@@ -1,0 +1,12 @@
+import { USDCNodeConfig } from '@stargatefinance/stg-devtools-v2'
+
+import { OmniGraphHardhat } from '@layerzerolabs/devtools-evm-hardhat'
+
+// For External USDT deployments,refernece packages/stg-evm-v2/devtools/config/mainnet/01/usdt-token.config.ts
+
+export default async (): Promise<OmniGraphHardhat<USDCNodeConfig, unknown>> => {
+    return {
+        contracts: [],
+        connections: [],
+    }
+}


### PR DESCRIPTION
## In this PR:
- Added config step to update token ownership of USDT to `StargateOFTUSDT` so that it can be the minter (only owner can mint)
- Added example of usdt external deployment format
- Added peaq USDT config script that will guide external USDT configs moving forward