### PR TITLE
Feat: refctor messaging in testnet

### DIFF
--- a/packages/stg-evm-v2/devtools/config/mainnet/01/credit-messaging.config.ts
+++ b/packages/stg-evm-v2/devtools/config/mainnet/01/credit-messaging.config.ts
@@ -2,8 +2,8 @@ import { CreditMessagingEdgeConfig, CreditMessagingNodeConfig } from '@stargatef
 
 import { OmniGraphHardhat, createGetHreByEid } from '@layerzerolabs/devtools-evm-hardhat'
 
-import { generateCreditMessagingConfig, getSafeAddress } from '../../utils'
-import { filterConnections, getContracts, isValidCreditMessagingChain, validCreditMessagingChains } from '../utils'
+import { filterConnections, generateCreditMessagingConfig, getSafeAddress } from '../../utils'
+import { getContracts, isValidCreditMessagingChain, validCreditMessagingChains } from '../utils'
 
 import { DEFAULT_PLANNER } from './constants'
 import { getMessagingAssetConfig } from './shared'

--- a/packages/stg-evm-v2/devtools/config/mainnet/01/token-messaging.config.ts
+++ b/packages/stg-evm-v2/devtools/config/mainnet/01/token-messaging.config.ts
@@ -2,8 +2,8 @@ import { TokenMessagingEdgeConfig, TokenMessagingNodeConfig } from '@stargatefin
 
 import { OmniGraphHardhat, createGetHreByEid } from '@layerzerolabs/devtools-evm-hardhat'
 
-import { generateTokenMessagingConfig, getSafeAddress } from '../../utils'
-import { filterConnections, getContracts, isValidTokenMessagingChain, validTokenMessagingChains } from '../utils'
+import { filterConnections, generateTokenMessagingConfig, getSafeAddress } from '../../utils'
+import { getContracts, isValidTokenMessagingChain, validTokenMessagingChains } from '../utils'
 
 import { DEFAULT_PLANNER } from './constants'
 import { getMessagingAssetConfig } from './shared'

--- a/packages/stg-evm-v2/devtools/config/mainnet/utils.ts
+++ b/packages/stg-evm-v2/devtools/config/mainnet/utils.ts
@@ -1,6 +1,8 @@
 import { withEid } from '@layerzerolabs/devtools'
 import { EndpointId } from '@layerzerolabs/lz-definitions'
 
+import { getContractsInChain } from '../utils'
+
 export const onAbstract = withEid(EndpointId.ABSTRACT_V2_MAINNET)
 export const onApe = withEid(EndpointId.APE_V2_MAINNET)
 export const onArb = withEid(EndpointId.ARBITRUM_V2_MAINNET)
@@ -233,26 +235,5 @@ export function isValidTokenMessagingChain(chain: string): boolean {
 }
 
 export function getContracts(chains: string[] | null, contract: any, isValidChain: (chain: string) => boolean) {
-    if (!chains || chains.length === 0) {
-        // If chains is null or empty, include all valid contracts
-        return Object.keys(chainFunctions)
-            .filter(isValidChain)
-            .map((chain) => chainFunctions[chain as keyof typeof chainFunctions](contract))
-    }
-
-    const invalidChains = chains.filter((chain) => !isValidChain(chain.trim()))
-    if (invalidChains.length > 0) {
-        throw new Error(`Invalid chains found: ${invalidChains.join(', ')}`)
-    }
-
-    return chains.map((chain) => chainFunctions[chain.trim() as keyof typeof chainFunctions](contract))
-}
-
-export function filterConnections(connections: any[], fromContracts: any[], toContracts: any[]) {
-    const fromEids = new Set(fromContracts.map((contract: { eid: any }) => contract.eid))
-    const toEids = new Set(toContracts.map((contract: { eid: any }) => contract.eid))
-
-    return connections.filter((connection: { from: { eid: any }; to: { eid: any } }) => {
-        return fromEids.has(connection.from.eid) && toEids.has(connection.to.eid)
-    })
+    return getContractsInChain(chains, contract, isValidChain, chainFunctions)
 }

--- a/packages/stg-evm-v2/devtools/config/testnet/credit-messaging.config.ts
+++ b/packages/stg-evm-v2/devtools/config/testnet/credit-messaging.config.ts
@@ -1,140 +1,52 @@
-import { ASSETS, TokenName } from '@stargatefinance/stg-definitions-v2'
 import { CreditMessagingEdgeConfig, CreditMessagingNodeConfig } from '@stargatefinance/stg-devtools-v2'
 
 import { OmniGraphHardhat, createGetHreByEid } from '@layerzerolabs/devtools-evm-hardhat'
-import { EndpointId } from '@layerzerolabs/lz-definitions'
 
-import { createGetAssetAddresses } from '../../../ts-src/utils/util'
-import { generateCreditMessagingConfig } from '../utils'
+import { filterConnections, generateCreditMessagingConfig } from '../utils'
 
 import { DEFAULT_PLANNER } from './constants'
-import { onArb, onBL3, onBsc, onEth, onKlaytn, onMantle, onOdyssey, onOpt } from './utils'
+import { getMessagingAssetConfig } from './shared'
+import { getContracts, isValidCreditMessagingChain, validCreditMessagingChains } from './utils'
 
 const contract = { contractName: 'CreditMessaging' }
 
 export default async (): Promise<OmniGraphHardhat<CreditMessagingNodeConfig, CreditMessagingEdgeConfig>> => {
-    // First let's create the HardhatRuntimeEnvironment objects for all networks
+    const fromChains = process.env.FROM_CHAINS ? process.env.FROM_CHAINS.split(',') : [...validCreditMessagingChains]
+    const toChains = process.env.TO_CHAINS ? process.env.TO_CHAINS.split(',') : [...validCreditMessagingChains]
+
+    console.log('CREDIT_MESSAGING FROM_CHAINS:', fromChains)
+    console.log('CREDIT_MESSAGING TO_CHAINS:', toChains)
+
+    let fromContracts
+    let toContracts
+    try {
+        fromContracts = getContracts(fromChains, contract, isValidCreditMessagingChain)
+        toContracts = getContracts(toChains, contract, isValidCreditMessagingChain)
+    } catch (error) {
+        console.error('Error getting contracts: ', error)
+        throw error
+    }
+
+    const contractMap = new Map()
+
+    fromContracts.forEach((contract) => contractMap.set(contract.eid, contract))
+    toContracts.forEach((contract) => contractMap.set(contract.eid, contract))
+
+    const allContracts = Array.from(contractMap.values())
+    const allConnections = generateCreditMessagingConfig(allContracts)
+    const filteredConnections = filterConnections(allConnections, fromContracts, toContracts)
+
     const getEnvironment = createGetHreByEid()
-
-    const ethCreditMsging = onEth(contract)
-    const bscCreditMsging = onBsc(contract)
-    const optCreditMsging = onOpt(contract)
-    const arbCreditMsging = onArb(contract)
-    const klaytnCreditMsging = onKlaytn(contract)
-    const bl3CreditMsging = onBL3(contract)
-    const odysseyCreditMsging = onOdyssey(contract)
-    const mantleCreditMsging = onMantle(contract)
-
-    // Now we collect the address of the deployed assets
-    const allAssets = [TokenName.USDT, TokenName.USDC, TokenName.ETH] as const
-    const getAssetAddresses = createGetAssetAddresses(getEnvironment)
-    const ethAssetAddresses = await getAssetAddresses(EndpointId.SEPOLIA_V2_TESTNET, allAssets)
-    const bscAssetAddresses = await getAssetAddresses(EndpointId.BSC_V2_TESTNET, [TokenName.USDT] as const)
-    const optAssetAddresses = await getAssetAddresses(EndpointId.OPTSEP_V2_TESTNET, allAssets)
-    const arbAssetAddresses = await getAssetAddresses(EndpointId.ARBSEP_V2_TESTNET, allAssets)
-    const klaytnAssetAddresses = await getAssetAddresses(EndpointId.KLAYTN_V2_TESTNET, allAssets)
-    const bl3AssetAddresses = await getAssetAddresses(EndpointId.BL3_V2_TESTNET, allAssets)
-    const odysseyAssetAddresses = await getAssetAddresses(EndpointId.ODYSSEY_V2_TESTNET, allAssets)
-    const mantleAssetAddresses = await getAssetAddresses(EndpointId.MANTLESEP_V2_TESTNET, allAssets)
+    const assetConfigs = await getMessagingAssetConfig(getEnvironment)
 
     return {
-        contracts: [
-            {
-                contract: ethCreditMsging,
-                config: {
-                    planner: DEFAULT_PLANNER,
-                    assets: {
-                        [ethAssetAddresses.USDT]: ASSETS[TokenName.USDT].assetId,
-                        [ethAssetAddresses.USDC]: ASSETS[TokenName.USDC].assetId,
-                        [ethAssetAddresses.ETH]: ASSETS[TokenName.ETH].assetId,
-                    },
-                },
+        contracts: allContracts.map((contract) => ({
+            contract,
+            config: {
+                planner: DEFAULT_PLANNER,
+                assets: assetConfigs[contract.eid as keyof typeof assetConfigs],
             },
-            {
-                contract: bscCreditMsging,
-                config: {
-                    planner: DEFAULT_PLANNER,
-                    assets: {
-                        [bscAssetAddresses.USDT]: ASSETS[TokenName.USDT].assetId,
-                    },
-                },
-            },
-            {
-                contract: optCreditMsging,
-                config: {
-                    planner: DEFAULT_PLANNER,
-                    assets: {
-                        [optAssetAddresses.USDT]: ASSETS[TokenName.USDT].assetId,
-                        [optAssetAddresses.USDC]: ASSETS[TokenName.USDC].assetId,
-                        [optAssetAddresses.ETH]: ASSETS[TokenName.ETH].assetId,
-                    },
-                },
-            },
-            {
-                contract: arbCreditMsging,
-                config: {
-                    planner: DEFAULT_PLANNER,
-                    assets: {
-                        [arbAssetAddresses.USDT]: ASSETS[TokenName.USDT].assetId,
-                        [arbAssetAddresses.USDC]: ASSETS[TokenName.USDC].assetId,
-                        [arbAssetAddresses.ETH]: ASSETS[TokenName.ETH].assetId,
-                    },
-                },
-            },
-            {
-                contract: klaytnCreditMsging,
-                config: {
-                    planner: DEFAULT_PLANNER,
-                    assets: {
-                        [klaytnAssetAddresses.USDT]: ASSETS[TokenName.USDT].assetId,
-                        [klaytnAssetAddresses.USDC]: ASSETS[TokenName.USDC].assetId,
-                        [klaytnAssetAddresses.ETH]: ASSETS[TokenName.ETH].assetId,
-                    },
-                },
-            },
-            {
-                contract: bl3CreditMsging,
-                config: {
-                    planner: DEFAULT_PLANNER,
-                    assets: {
-                        [bl3AssetAddresses.USDT]: ASSETS[TokenName.USDT].assetId,
-                        [bl3AssetAddresses.USDC]: ASSETS[TokenName.USDC].assetId,
-                        [bl3AssetAddresses.ETH]: ASSETS[TokenName.ETH].assetId,
-                    },
-                },
-            },
-            {
-                contract: odysseyCreditMsging,
-                config: {
-                    planner: DEFAULT_PLANNER,
-                    assets: {
-                        [odysseyAssetAddresses.USDT]: ASSETS[TokenName.USDT].assetId,
-                        [odysseyAssetAddresses.USDC]: ASSETS[TokenName.USDC].assetId,
-                        [odysseyAssetAddresses.ETH]: ASSETS[TokenName.ETH].assetId,
-                    },
-                },
-            },
-            {
-                contract: mantleCreditMsging,
-                config: {
-                    planner: DEFAULT_PLANNER,
-                    assets: {
-                        [mantleAssetAddresses.USDT]: ASSETS[TokenName.USDT].assetId,
-                        [mantleAssetAddresses.USDC]: ASSETS[TokenName.USDC].assetId,
-                        [mantleAssetAddresses.ETH]: ASSETS[TokenName.ETH].assetId,
-                    },
-                },
-            },
-        ],
-        connections: generateCreditMessagingConfig([
-            ethCreditMsging,
-            bscCreditMsging,
-            optCreditMsging,
-            arbCreditMsging,
-            klaytnCreditMsging,
-            bl3CreditMsging,
-            odysseyCreditMsging,
-            mantleCreditMsging,
-        ]),
+        })),
+        connections: filteredConnections,
     }
 }

--- a/packages/stg-evm-v2/devtools/config/testnet/shared.ts
+++ b/packages/stg-evm-v2/devtools/config/testnet/shared.ts
@@ -1,0 +1,62 @@
+import { ASSETS, TokenName } from '@stargatefinance/stg-definitions-v2'
+import { MessagingAssetConfig } from '@stargatefinance/stg-devtools-v2'
+
+import { createGetHreByEid } from '@layerzerolabs/devtools-evm-hardhat'
+import { EndpointId } from '@layerzerolabs/lz-definitions'
+
+import { createGetAssetAddresses } from '../../../ts-src/utils/util'
+
+export const getMessagingAssetConfig = async (getEnvironment = createGetHreByEid()) => {
+    const allAssets = [TokenName.USDT, TokenName.USDC, TokenName.ETH] as const
+    const getAssetAddresses = createGetAssetAddresses(getEnvironment)
+
+    const arbAssetAddresses = await getAssetAddresses(EndpointId.ARBSEP_V2_TESTNET, allAssets)
+    const bscAssetAddresses = await getAssetAddresses(EndpointId.BSC_V2_TESTNET, [TokenName.USDT] as const)
+    const bl3AssetAddresses = await getAssetAddresses(EndpointId.BL3_V2_TESTNET, allAssets)
+    const ethAssetAddresses = await getAssetAddresses(EndpointId.SEPOLIA_V2_TESTNET, allAssets)
+    const klaytnAssetAddresses = await getAssetAddresses(EndpointId.KLAYTN_V2_TESTNET, allAssets)
+    const mantleAssetAddresses = await getAssetAddresses(EndpointId.MANTLESEP_V2_TESTNET, allAssets)
+    const optAssetAddresses = await getAssetAddresses(EndpointId.OPTSEP_V2_TESTNET, allAssets)
+    const odysseyAssetAddresses = await getAssetAddresses(EndpointId.ODYSSEY_V2_TESTNET, allAssets)
+
+    return {
+        [EndpointId.ARBSEP_V2_TESTNET]: {
+            [arbAssetAddresses.ETH]: ASSETS[TokenName.ETH].assetId,
+            [arbAssetAddresses.USDC]: ASSETS[TokenName.USDC].assetId,
+            [arbAssetAddresses.USDT]: ASSETS[TokenName.USDT].assetId,
+        },
+        [EndpointId.BSC_V2_TESTNET]: {
+            [bscAssetAddresses.USDT]: ASSETS[TokenName.USDT].assetId,
+        },
+        [EndpointId.BL3_V2_TESTNET]: {
+            [bl3AssetAddresses.ETH]: ASSETS[TokenName.ETH].assetId,
+            [bl3AssetAddresses.USDC]: ASSETS[TokenName.USDC].assetId,
+            [bl3AssetAddresses.USDT]: ASSETS[TokenName.USDT].assetId,
+        },
+        [EndpointId.SEPOLIA_V2_TESTNET]: {
+            [ethAssetAddresses.ETH]: ASSETS[TokenName.ETH].assetId,
+            [ethAssetAddresses.USDC]: ASSETS[TokenName.USDC].assetId,
+            [ethAssetAddresses.USDT]: ASSETS[TokenName.USDT].assetId,
+        },
+        [EndpointId.KLAYTN_V2_TESTNET]: {
+            [klaytnAssetAddresses.ETH]: ASSETS[TokenName.ETH].assetId,
+            [klaytnAssetAddresses.USDC]: ASSETS[TokenName.USDC].assetId,
+            [klaytnAssetAddresses.USDT]: ASSETS[TokenName.USDT].assetId,
+        },
+        [EndpointId.MANTLESEP_V2_TESTNET]: {
+            [mantleAssetAddresses.ETH]: ASSETS[TokenName.ETH].assetId,
+            [mantleAssetAddresses.USDC]: ASSETS[TokenName.USDC].assetId,
+            [mantleAssetAddresses.USDT]: ASSETS[TokenName.USDT].assetId,
+        },
+        [EndpointId.OPTSEP_V2_TESTNET]: {
+            [optAssetAddresses.ETH]: ASSETS[TokenName.ETH].assetId,
+            [optAssetAddresses.USDC]: ASSETS[TokenName.USDC].assetId,
+            [optAssetAddresses.USDT]: ASSETS[TokenName.USDT].assetId,
+        },
+        [EndpointId.ODYSSEY_V2_TESTNET]: {
+            [odysseyAssetAddresses.ETH]: ASSETS[TokenName.ETH].assetId,
+            [odysseyAssetAddresses.USDC]: ASSETS[TokenName.USDC].assetId,
+            [odysseyAssetAddresses.USDT]: ASSETS[TokenName.USDT].assetId,
+        },
+    } satisfies Partial<Record<EndpointId, MessagingAssetConfig>>
+}

--- a/packages/stg-evm-v2/devtools/config/testnet/token-messaging.config.ts
+++ b/packages/stg-evm-v2/devtools/config/testnet/token-messaging.config.ts
@@ -1,143 +1,53 @@
-import { ASSETS, TokenName } from '@stargatefinance/stg-definitions-v2'
 import { TokenMessagingEdgeConfig, TokenMessagingNodeConfig } from '@stargatefinance/stg-devtools-v2'
 
 import { OmniGraphHardhat, createGetHreByEid } from '@layerzerolabs/devtools-evm-hardhat'
-import { EndpointId } from '@layerzerolabs/lz-definitions'
 
-import { createGetAssetAddresses } from '../../../ts-src/utils/util'
-import { generateTokenMessagingConfig } from '../utils'
+import { filterConnections, generateTokenMessagingConfig } from '../utils'
 
 import { DEFAULT_PLANNER } from './constants'
-import { onArb, onBL3, onBsc, onEth, onKlaytn, onMantle, onOdyssey, onOpt } from './utils'
+import { getMessagingAssetConfig } from './shared'
+import { getContracts, isValidTokenMessagingChain, validTokenMessagingChains } from './utils'
 
 const contract = { contractName: 'TokenMessaging' }
 
 export default async (): Promise<OmniGraphHardhat<TokenMessagingNodeConfig, TokenMessagingEdgeConfig>> => {
-    const getEnvironment = createGetHreByEid()
+    const fromChains = process.env.FROM_CHAINS ? process.env.FROM_CHAINS.split(',') : [...validTokenMessagingChains]
+    const toChains = process.env.TO_CHAINS ? process.env.TO_CHAINS.split(',') : [...validTokenMessagingChains]
 
-    const ethTokenMsging = onEth(contract)
-    const bscTokenMsging = onBsc(contract)
-    const optTokenMsging = onOpt(contract)
-    const arbTokenMsging = onArb(contract)
-    const klaytnTokenMsging = onKlaytn(contract)
-    const bl3TokenMsging = onBL3(contract)
-    const odysseyTokenMsging = onOdyssey(contract)
-    const mantleTokenMsging = onMantle(contract)
+    console.log('TOKEN_MESSAGING FROM_CHAINS:', fromChains)
+    console.log('TOKEN_MESSAGING TO_CHAINS:', toChains)
 
-    const defaultNodeConfig: TokenMessagingNodeConfig = {
-        planner: DEFAULT_PLANNER,
+    let fromContracts
+    let toContracts
+    try {
+        fromContracts = getContracts(fromChains, contract, isValidTokenMessagingChain)
+        toContracts = getContracts(toChains, contract, isValidTokenMessagingChain)
+    } catch (error) {
+        console.error('Error getting contracts: ', error)
+        throw error
     }
 
-    // Now we collect the address of the deployed assets
-    const allAssets = [TokenName.USDT, TokenName.USDC, TokenName.ETH] as const
-    const getAssetAddresses = createGetAssetAddresses(getEnvironment)
-    const ethAssetAddresses = await getAssetAddresses(EndpointId.SEPOLIA_V2_TESTNET, allAssets)
-    const bscAssetAddresses = await getAssetAddresses(EndpointId.BSC_V2_TESTNET, [TokenName.USDT] as const)
-    const optAssetAddresses = await getAssetAddresses(EndpointId.OPTSEP_V2_TESTNET, allAssets)
-    const arbAssetAddresses = await getAssetAddresses(EndpointId.ARBSEP_V2_TESTNET, allAssets)
-    const klaytnAssetAddresses = await getAssetAddresses(EndpointId.KLAYTN_V2_TESTNET, allAssets)
-    const bl3AssetAddresses = await getAssetAddresses(EndpointId.BL3_V2_TESTNET, allAssets)
-    const odysseyAssetAddresses = await getAssetAddresses(EndpointId.ODYSSEY_V2_TESTNET, allAssets)
-    const mantleAssetAddresses = await getAssetAddresses(EndpointId.MANTLESEP_V2_TESTNET, allAssets)
+    const contractMap = new Map()
+
+    fromContracts.forEach((contract) => contractMap.set(contract.eid, contract))
+
+    toContracts.forEach((contract) => contractMap.set(contract.eid, contract))
+
+    const allContracts = Array.from(contractMap.values())
+    const allConnections = generateTokenMessagingConfig(allContracts)
+    const filteredConnections = filterConnections(allConnections, fromContracts, toContracts)
+
+    const getEnvironment = createGetHreByEid()
+    const assetConfigs = await getMessagingAssetConfig(getEnvironment)
 
     return {
-        contracts: [
-            {
-                contract: ethTokenMsging,
-                config: {
-                    ...defaultNodeConfig,
-                    assets: {
-                        [ethAssetAddresses.USDT]: ASSETS.USDT.assetId,
-                        [ethAssetAddresses.USDC]: ASSETS.USDC.assetId,
-                        [ethAssetAddresses.ETH]: ASSETS.ETH.assetId,
-                    },
-                },
+        contracts: allContracts.map((contract) => ({
+            contract,
+            config: {
+                planner: DEFAULT_PLANNER,
+                assets: assetConfigs[contract.eid as keyof typeof assetConfigs],
             },
-            {
-                contract: bscTokenMsging,
-                config: {
-                    ...defaultNodeConfig,
-                    assets: {
-                        [bscAssetAddresses.USDT]: ASSETS.USDT.assetId,
-                    },
-                },
-            },
-            {
-                contract: optTokenMsging,
-                config: {
-                    ...defaultNodeConfig,
-                    assets: {
-                        [optAssetAddresses.USDT]: ASSETS.USDT.assetId,
-                        [optAssetAddresses.USDC]: ASSETS.USDC.assetId,
-                        [optAssetAddresses.ETH]: ASSETS.ETH.assetId,
-                    },
-                },
-            },
-            {
-                contract: arbTokenMsging,
-                config: {
-                    ...defaultNodeConfig,
-                    assets: {
-                        [arbAssetAddresses.USDT]: ASSETS.USDT.assetId,
-                        [arbAssetAddresses.USDC]: ASSETS.USDC.assetId,
-                        [arbAssetAddresses.ETH]: ASSETS.ETH.assetId,
-                    },
-                },
-            },
-            {
-                contract: klaytnTokenMsging,
-                config: {
-                    ...defaultNodeConfig,
-                    assets: {
-                        [klaytnAssetAddresses.USDT]: ASSETS.USDT.assetId,
-                        [klaytnAssetAddresses.USDC]: ASSETS.USDC.assetId,
-                        [klaytnAssetAddresses.ETH]: ASSETS.ETH.assetId,
-                    },
-                },
-            },
-            {
-                contract: bl3TokenMsging,
-                config: {
-                    ...defaultNodeConfig,
-                    assets: {
-                        [bl3AssetAddresses.USDT]: ASSETS.USDT.assetId,
-                        [bl3AssetAddresses.USDC]: ASSETS.USDC.assetId,
-                        [bl3AssetAddresses.ETH]: ASSETS.ETH.assetId,
-                    },
-                },
-            },
-            {
-                contract: odysseyTokenMsging,
-                config: {
-                    ...defaultNodeConfig,
-                    assets: {
-                        [odysseyAssetAddresses.USDT]: ASSETS.USDT.assetId,
-                        [odysseyAssetAddresses.USDC]: ASSETS.USDC.assetId,
-                        [odysseyAssetAddresses.ETH]: ASSETS.ETH.assetId,
-                    },
-                },
-            },
-            {
-                contract: mantleTokenMsging,
-                config: {
-                    ...defaultNodeConfig,
-                    assets: {
-                        [mantleAssetAddresses.USDT]: ASSETS.USDT.assetId,
-                        [mantleAssetAddresses.USDC]: ASSETS.USDC.assetId,
-                        [mantleAssetAddresses.ETH]: ASSETS.ETH.assetId,
-                    },
-                },
-            },
-        ],
-        connections: generateTokenMessagingConfig([
-            ethTokenMsging,
-            bscTokenMsging,
-            optTokenMsging,
-            arbTokenMsging,
-            klaytnTokenMsging,
-            bl3TokenMsging,
-            odysseyTokenMsging,
-            mantleTokenMsging,
-        ]),
+        })),
+        connections: filteredConnections,
     }
 }

--- a/packages/stg-evm-v2/devtools/config/testnet/utils.ts
+++ b/packages/stg-evm-v2/devtools/config/testnet/utils.ts
@@ -35,8 +35,24 @@ export const validCreditMessagingChains = new Set([
     // Add other valid chains for credit messaging
 ])
 
+export const validTokenMessagingChains = new Set([
+    'arbsep-testnet',
+    'bl3-testnet',
+    'bsc-testnet',
+    'klaytn-testnet',
+    'mantle-testnet',
+    'odyssey-testnet',
+    'opt-testnet',
+    'sepolia-testnet',
+    // Add other valid chains for token messaging
+])
+
 export function isValidCreditMessagingChain(chain: string): boolean {
     return validCreditMessagingChains.has(chain)
+}
+
+export function isValidTokenMessagingChain(chain: string): boolean {
+    return validTokenMessagingChains.has(chain)
 }
 
 export function getContracts(chains: string[] | null, contract: any, isValidChain: (chain: string) => boolean) {

--- a/packages/stg-evm-v2/devtools/config/testnet/utils.ts
+++ b/packages/stg-evm-v2/devtools/config/testnet/utils.ts
@@ -1,7 +1,7 @@
 import { withEid } from '@layerzerolabs/devtools'
 import { EndpointId } from '@layerzerolabs/lz-definitions'
 
-import { getContractsInChain } from '../utils'
+import { getContractsInChain, setsDifference } from '../utils'
 
 export const onEth = withEid(EndpointId.SEPOLIA_V2_TESTNET)
 export const onBsc = withEid(EndpointId.BSC_V2_TESTNET)
@@ -23,29 +23,17 @@ export const chainFunctions = {
     'sepolia-testnet': onEth,
 }
 
-export const validCreditMessagingChains = new Set([
-    'arbsep-testnet',
-    'bl3-testnet',
-    'bsc-testnet',
-    'klaytn-testnet',
-    'mantle-testnet',
-    'odyssey-testnet',
-    'opt-testnet',
-    'sepolia-testnet',
-    // Add other valid chains for credit messaging
+export const allChains = new Set(Object.keys(chainFunctions))
+
+const excludedCreditMessagingChains = new Set([
+    // Add invalid chains for credit messaging
+])
+const excludedTokenMessagingChains = new Set([
+    // Add invalid chains for token messaging
 ])
 
-export const validTokenMessagingChains = new Set([
-    'arbsep-testnet',
-    'bl3-testnet',
-    'bsc-testnet',
-    'klaytn-testnet',
-    'mantle-testnet',
-    'odyssey-testnet',
-    'opt-testnet',
-    'sepolia-testnet',
-    // Add other valid chains for token messaging
-])
+export const validCreditMessagingChains = setsDifference(allChains, excludedCreditMessagingChains)
+export const validTokenMessagingChains = setsDifference(allChains, excludedTokenMessagingChains)
 
 export function isValidCreditMessagingChain(chain: string): boolean {
     return validCreditMessagingChains.has(chain)

--- a/packages/stg-evm-v2/devtools/config/testnet/utils.ts
+++ b/packages/stg-evm-v2/devtools/config/testnet/utils.ts
@@ -1,6 +1,8 @@
 import { withEid } from '@layerzerolabs/devtools'
 import { EndpointId } from '@layerzerolabs/lz-definitions'
 
+import { getContractsInChain } from '../utils'
+
 export const onEth = withEid(EndpointId.SEPOLIA_V2_TESTNET)
 export const onBsc = withEid(EndpointId.BSC_V2_TESTNET)
 export const onArb = withEid(EndpointId.ARBSEP_V2_TESTNET)
@@ -9,3 +11,34 @@ export const onKlaytn = withEid(EndpointId.KLAYTN_V2_TESTNET)
 export const onBL3 = withEid(EndpointId.BL3_V2_TESTNET)
 export const onOdyssey = withEid(EndpointId.ODYSSEY_V2_TESTNET)
 export const onMantle = withEid(EndpointId.MANTLESEP_V2_TESTNET)
+
+export const chainFunctions = {
+    'arbsep-testnet': onArb,
+    'bl3-testnet': onBL3,
+    'bsc-testnet': onBsc,
+    'klaytn-testnet': onKlaytn,
+    'mantle-testnet': onMantle,
+    'odyssey-testnet': onOdyssey,
+    'opt-testnet': onOpt,
+    'sepolia-testnet': onEth,
+}
+
+export const validCreditMessagingChains = new Set([
+    'arbsep-testnet',
+    'bl3-testnet',
+    'bsc-testnet',
+    'klaytn-testnet',
+    'mantle-testnet',
+    'odyssey-testnet',
+    'opt-testnet',
+    'sepolia-testnet',
+    // Add other valid chains for credit messaging
+])
+
+export function isValidCreditMessagingChain(chain: string): boolean {
+    return validCreditMessagingChains.has(chain)
+}
+
+export function getContracts(chains: string[] | null, contract: any, isValidChain: (chain: string) => boolean) {
+    return getContractsInChain(chains, contract, isValidChain, chainFunctions)
+}

--- a/packages/stg-evm-v2/devtools/config/testnet/utils.ts
+++ b/packages/stg-evm-v2/devtools/config/testnet/utils.ts
@@ -26,10 +26,10 @@ export const chainFunctions = {
 export const allChains = new Set(Object.keys(chainFunctions))
 
 const excludedCreditMessagingChains = new Set([
-    // Add invalid chains for credit messaging
+    // Add chains that should be excluded from credit messaging
 ])
 const excludedTokenMessagingChains = new Set([
-    // Add invalid chains for token messaging
+    // Add chains that should be excluded from token messaging
 ])
 
 export const validCreditMessagingChains = setsDifference(allChains, excludedCreditMessagingChains)

--- a/packages/stg-evm-v2/devtools/config/utils.ts
+++ b/packages/stg-evm-v2/devtools/config/utils.ts
@@ -203,3 +203,33 @@ export const getSafeAddress = (eid: EndpointId): string => getSafeConfig(eid).sa
  * Tiny helper around non-null assert
  */
 const assertAndReturn = <T>(value: T | null | undefined, message: string): T => (assert(value != null, message), value)
+
+export function getContractsInChain(
+    chains: string[] | null,
+    contract: any,
+    isValidChain: (chain: string) => boolean,
+    chainFunctions: any
+) {
+    if (!chains || chains.length === 0) {
+        // If chains is null or empty, include all valid contracts
+        return Object.keys(chainFunctions)
+            .filter(isValidChain)
+            .map((chain) => chainFunctions[chain as keyof typeof chainFunctions](contract))
+    }
+
+    const invalidChains = chains.filter((chain) => !isValidChain(chain.trim()))
+    if (invalidChains.length > 0) {
+        throw new Error(`Invalid chains found: ${invalidChains.join(', ')}`)
+    }
+
+    return chains.map((chain) => chainFunctions[chain.trim() as keyof typeof chainFunctions](contract))
+}
+
+export function filterConnections(connections: any[], fromContracts: any[], toContracts: any[]) {
+    const fromEids = new Set(fromContracts.map((contract: { eid: any }) => contract.eid))
+    const toEids = new Set(toContracts.map((contract: { eid: any }) => contract.eid))
+
+    return connections.filter((connection: { from: { eid: any }; to: { eid: any } }) => {
+        return fromEids.has(connection.from.eid) && toEids.has(connection.to.eid)
+    })
+}

--- a/packages/stg-evm-v2/devtools/config/utils.ts
+++ b/packages/stg-evm-v2/devtools/config/utils.ts
@@ -233,3 +233,13 @@ export function filterConnections(connections: any[], fromContracts: any[], toCo
         return fromEids.has(connection.from.eid) && toEids.has(connection.to.eid)
     })
 }
+
+/**
+ * Returns the difference between two sets
+ * @param setA - The first set
+ * @param setB - The second set
+ * @returns A new set containing elements that are in setA but not in setB
+ */
+export function setsDifference(setA: Set<string>, setB: Set<string>): Set<string> {
+    return new Set<string>([...setA].filter((x) => !setB.has(x)))
+}

--- a/packages/stg-evm-v2/test/devtools/utils.test.ts
+++ b/packages/stg-evm-v2/test/devtools/utils.test.ts
@@ -7,11 +7,16 @@ import { assertHardhatDeploy, createGetHreByEid } from '@layerzerolabs/devtools-
 import { EndpointId } from '@layerzerolabs/lz-definitions'
 
 import {
-    filterConnections,
-    getContracts,
-    isValidCreditMessagingChain,
-    validCreditMessagingChains,
+    getContracts as getContractsMainnet,
+    isValidCreditMessagingChain as isValidCreditMessagingChainMainnet,
+    validCreditMessagingChains as validCreditMessagingChainsMainnet,
 } from '../../devtools/config/mainnet/utils'
+import {
+    getContracts as getContractsTestnet,
+    isValidCreditMessagingChain as isValidCreditMessagingChainTestnet,
+    validCreditMessagingChains as validCreditMessagingChainsTestnet,
+} from '../../devtools/config/testnet/utils'
+import { filterConnections } from '../../devtools/config/utils'
 import { createGetAssetAddresses, createGetLPTokenAddresses, getAddress } from '../../ts-src/utils/util'
 
 describe('devtools/utils', () => {
@@ -105,15 +110,23 @@ describe('devtools/utils', () => {
         const mockContractData = { contractName: 'MockContract' }
 
         it('should return all valid contracts when chains is null', () => {
-            const result = getContracts(null, mockContractData, isValidCreditMessagingChain)
-            expect(result.length).to.equal(validCreditMessagingChains.size)
+            // Mainnet
+            const result = getContractsMainnet(null, mockContractData, isValidCreditMessagingChainMainnet)
+            expect(result.length).to.equal(validCreditMessagingChainsMainnet.size)
             expect(result[0]).to.have.property('eid')
             expect(result[0]).to.have.property('contractName', 'MockContract')
+
+            // Testnet
+            const resultTestnet = getContractsTestnet(null, mockContractData, isValidCreditMessagingChainTestnet)
+            expect(resultTestnet.length).to.equal(validCreditMessagingChainsTestnet.size)
+            expect(resultTestnet[0]).to.have.property('eid')
+            expect(resultTestnet[0]).to.have.property('contractName', 'MockContract')
         })
 
         it('should return specified contracts for valid chain names', () => {
+            // Mainnet
             const chains = ['ethereum-mainnet', 'arbitrum-mainnet', 'optimism-mainnet', 'base-mainnet']
-            const result = getContracts(chains, mockContractData, isValidCreditMessagingChain)
+            const result = getContractsMainnet(chains, mockContractData, isValidCreditMessagingChainMainnet)
             expect(result.length).to.equal(4)
             expect(result.map((r) => r.eid)).to.have.members([
                 EndpointId.ETHEREUM_V2_MAINNET,
@@ -121,9 +134,25 @@ describe('devtools/utils', () => {
                 EndpointId.OPTIMISM_V2_MAINNET,
                 EndpointId.BASE_V2_MAINNET,
             ])
+
+            // Testnet
+            const chainsTestnet = ['arbsep-testnet', 'bsc-testnet', 'sepolia-testnet', 'opt-testnet']
+            const resultTestnet = getContractsTestnet(
+                chainsTestnet,
+                mockContractData,
+                isValidCreditMessagingChainTestnet
+            )
+            expect(resultTestnet.length).to.equal(4)
+            expect(resultTestnet.map((r) => r.eid)).to.have.members([
+                EndpointId.ARBSEP_V2_TESTNET,
+                EndpointId.BSC_V2_TESTNET,
+                EndpointId.SEPOLIA_V2_TESTNET,
+                EndpointId.OPTSEP_V2_TESTNET,
+            ])
         })
 
         it('should throw an error for invalid chain names', () => {
+            // Mainnet
             const chains = [
                 'ethereum-mainnet',
                 'invalid-chain-1',
@@ -131,25 +160,51 @@ describe('devtools/utils', () => {
                 'invalid-chain-2',
                 'base-mainnet',
             ]
-            expect(() => getContracts(chains, mockContractData, isValidCreditMessagingChain)).to.throw(
+            expect(() => getContractsMainnet(chains, mockContractData, isValidCreditMessagingChainMainnet)).to.throw(
                 'Invalid chains found: invalid-chain-1, invalid-chain-2'
             )
+
+            // Testnet
+            const chainsTestnet = ['arbsep-testnet', 'invalid-chain-1', 'bsc-testnet', 'invalid-chain-2']
+            expect(() =>
+                getContractsTestnet(chainsTestnet, mockContractData, isValidCreditMessagingChainTestnet)
+            ).to.throw('Invalid chains found: invalid-chain-1, invalid-chain-2')
         })
 
         it('should trim whitespace from chain names', () => {
+            // Mainnet
             const chains = [' ethereum-mainnet', 'arbitrum-mainnet ', '  base-mainnet']
-            const result = getContracts(chains, mockContractData, isValidCreditMessagingChain)
+            const result = getContractsMainnet(chains, mockContractData, isValidCreditMessagingChainMainnet)
             expect(result.length).to.equal(3)
             expect(result.map((r) => r.eid)).to.have.members([
                 EndpointId.ETHEREUM_V2_MAINNET,
                 EndpointId.ARBITRUM_V2_MAINNET,
                 EndpointId.BASE_V2_MAINNET,
             ])
+
+            // Testnet
+            const chainsTestnet = ['arbsep-testnet     ', '    bsc-testnet', ' sepolia-testnet ']
+            const resultTestnet = getContractsTestnet(
+                chainsTestnet,
+                mockContractData,
+                isValidCreditMessagingChainTestnet
+            )
+            expect(resultTestnet.length).to.equal(3)
+            expect(resultTestnet.map((r) => r.eid)).to.have.members([
+                EndpointId.ARBSEP_V2_TESTNET,
+                EndpointId.BSC_V2_TESTNET,
+                EndpointId.SEPOLIA_V2_TESTNET,
+            ])
         })
 
         it('should return all valid contracts for an empty input array', () => {
-            const result = getContracts([], mockContractData, isValidCreditMessagingChain)
-            expect(result.length).to.equal(validCreditMessagingChains.size)
+            // Mainnet
+            const result = getContractsMainnet([], mockContractData, isValidCreditMessagingChainMainnet)
+            expect(result.length).to.equal(validCreditMessagingChainsMainnet.size)
+
+            // Testnet
+            const resultTestnet = getContractsTestnet([], mockContractData, isValidCreditMessagingChainTestnet)
+            expect(resultTestnet.length).to.equal(validCreditMessagingChainsTestnet.size)
         })
     })
 

--- a/packages/stg-evm-v2/test/devtools/utils.test.ts
+++ b/packages/stg-evm-v2/test/devtools/utils.test.ts
@@ -16,7 +16,7 @@ import {
     isValidCreditMessagingChain as isValidCreditMessagingChainTestnet,
     validCreditMessagingChains as validCreditMessagingChainsTestnet,
 } from '../../devtools/config/testnet/utils'
-import { filterConnections } from '../../devtools/config/utils'
+import { filterConnections, setsDifference } from '../../devtools/config/utils'
 import { createGetAssetAddresses, createGetLPTokenAddresses, getAddress } from '../../ts-src/utils/util'
 
 describe('devtools/utils', () => {
@@ -265,6 +265,44 @@ describe('devtools/utils', () => {
             expect(result).to.deep.include({ from: { eid: 1 }, to: { eid: 4 } })
             expect(result).to.deep.include({ from: { eid: 2 }, to: { eid: 3 } })
             expect(result).to.deep.include({ from: { eid: 2 }, to: { eid: 4 } })
+        })
+    })
+
+    describe.only('setsDifference', () => {
+        const mockContractData = { contractName: 'MockContract' }
+
+        it('should return empty set when sets are identical', () => {
+            const setA = new Set(['a', 'b', 'c'])
+            const result = setsDifference(setA, setA)
+
+            expect(result.size).to.equal(0)
+        })
+
+        it('should return all elements when sets are disjoint', () => {
+            const setA = new Set(['a', 'b', 'c'])
+            const setB = new Set(['d', 'e', 'f'])
+            const result = setsDifference(setA, setB)
+
+            expect(result.size).to.equal(setA.size)
+            expect(result).to.deep.equal(setA)
+        })
+
+        it('should return elements in setA that are not in setB', () => {
+            const setA = new Set(['a', 'b', 'c'])
+            const setB = new Set(['b', 'd', 'e'])
+            const result = setsDifference(setA, setB)
+
+            expect(result.size).to.equal(2)
+            expect(result).to.deep.equal(new Set(['a', 'c']))
+        })
+
+        it('should handle empty sets', () => {
+            const setA = new Set(['a', 'b', 'c'])
+            const setB = new Set([])
+            const result = setsDifference(setA, setB)
+
+            expect(result.size).to.equal(setA.size)
+            expect(result).to.deep.equal(setA)
         })
     })
 })


### PR DESCRIPTION
This PR refactors the credit messaging configuration (`credit-messaging.config`) and token messaging config (`token-messaging.config`) in Testnet.
The same work was already done in PR #279 and #301