### PR TITLE
Bump Glue Gas configs

### DIFF
--- a/.changeset/cyan-deers-greet.md
+++ b/.changeset/cyan-deers-greet.md
@@ -1,0 +1,5 @@
+---
+"@stargatefinance/stg-definitions-v2": patch
+---
+
+bump credits

--- a/packages/stg-definitions-v2/src/constant.ts
+++ b/packages/stg-definitions-v2/src/constant.ts
@@ -1717,7 +1717,7 @@ export const NETWORKS: NetworksConfig = {
             ...DEFAULT_CREDIT_MESSAGING_NETWORK_CONFIG,
             requiredDVNs: [DVNS.NETHERMIND[EndpointId.GLUE_V2_MAINNET], DVNS.STG[EndpointId.GLUE_V2_MAINNET]],
             executor: EXECUTORS.LZ_LABS[EndpointId.GLUE_V2_MAINNET],
-            sendCreditGasLimit: 195000n,
+            sendCreditGasLimit: 255000n,
         },
         tokenMessaging: {
             ...DEFAULT_TOKEN_MESSAGING_NETWORK_CONFIG,
@@ -1725,9 +1725,9 @@ export const NETWORKS: NetworksConfig = {
             executor: EXECUTORS.LZ_LABS[EndpointId.GLUE_V2_MAINNET],
             nativeDropAmount: parseEther('0.5').toBigInt(),
             taxiGasLimit: 350000n,
-            busGasLimit: 160000n,
-            busRideGasLimit: 85000n,
-            nativeDropGasLimit: 45000n,
+            busGasLimit: 2200000n,
+            busRideGasLimit: 145000n,
+            nativeDropGasLimit: 145000n,
         },
         safeConfig: {
             safeAddress: '0x6C0d029292f48068f576515c79Fc6bCDec5F58DA',


### PR DESCRIPTION
In this PR: 
Glue transactions are occasionally consuming more gas than our current configs. 

This PR introduces higher gas limits for sendCredits, nativeDrop and busRides