### PR TITLE
fix: test failure due to vm.addr(1) having code on mainnet 

### DIFF
--- a/packages/stg-evm-v2/test/unitest/peripheral/zapper/StargateZapperV1.t.sol
+++ b/packages/stg-evm-v2/test/unitest/peripheral/zapper/StargateZapperV1.t.sol
@@ -19,6 +19,8 @@ import { StargatePoolNative } from "../../../../src/StargatePoolNative.sol";
 
 contract StargateZapperV1Test is StargateBaseTest {
     using SafeERC20 for IERC20;
+    uint256 constant PRE_PECTRA_BLOCK_NUMBER = 22431084 - 1;
+
     StargateStaking staking;
     StargateZapperV1 zapper;
     IStargateV1Router routerV1 = IStargateV1Router(0x8731d54E9D02c286767d56ac03e8037C07e01e98);
@@ -47,7 +49,8 @@ contract StargateZapperV1Test is StargateBaseTest {
 
     function setUp() public override {
         super.setUp();
-        vm.createSelectFork(vm.rpcUrl("ethereum_mainnet"));
+        // forking before pectra update, because after it, EOAs might have code, and this test assumes that vm.addr(1) has no code
+        vm.createSelectFork(vm.rpcUrl("ethereum_mainnet"), PRE_PECTRA_BLOCK_NUMBER);
 
         token1 = new TestToken("Test1", "TST1", 0);
         token2 = new TestToken("Test2", "TST2", 0);


### PR DESCRIPTION
After the Pectra update, EOAs can have code, which is causing `StargateZapperV1Test::test_RecoverToken` test to fail.

The issue is due to `StargateZapperV1Test` is forking mainnet in the [setup](https://github.com/stargate-protocol/stargate-v2/blob/391728d210074e97615b27a062c2eadeca7c0355/packages/stg-evm-v2/test/unitest/peripheral/zapper/StargateZapperV1.t.sol#L50), and in the [test_RecoverToken](https://github.com/stargate-protocol/stargate-v2/blob/391728d210074e97615b27a062c2eadeca7c0355/packages/stg-evm-v2/test/unitest/stargate/StargateBase.t.sol#L190) it tries to call `transfer` function in `vm.addr(1)`. 
`vm.addr(1)` is expected to be an EOA and successfully do the call, but since block [22447040](https://etherscan.io/tx/0x1db07e45d714389a77697fe88d1615a044ec997a4cd9bfec1f66ee220d5bddee) in mainnet this EOA has code, and this is causing the test to fail. 

This PR solves this issue by forking mainnet on a block prior the Pectra update, ensuring that non EOA has code at this point. 