### PR TITLE
Fix Typo in IMultiRewarder.sol Documentation Comment

### DIFF
--- a/packages/stg-evm-v2/src/peripheral/rewarder/interfaces/IMultiRewarder.sol
+++ b/packages/stg-evm-v2/src/peripheral/rewarder/interfaces/IMultiRewarder.sol
@@ -70,7 +70,7 @@ interface IMultiRewarder is IRewarder {
      *          been explicitly stopped.
      */
     event RewardRegistered(address indexed rewardToken);
-    /// @notice Emitted when the reward pool has been adjusted or intialized, with the new params.
+    /// @notice Emitted when the reward pool has been adjusted or initialized, with the new params.
     event RewardSet(
         address indexed rewardToken,
         uint256 amountAdded,


### PR DESCRIPTION


Description:  
This pull request corrects a typo in the documentation comment for the IMultiRewarder interface. The word "intialized" has been updated to the correct spelling "initialized" in the @notice comment describing the RewardRegistered event. No functional changes were made to the code.
