### PR TITLE
🐞 Fixing concurrency issue causing intermittent build failures

### DIFF
--- a/packages/stg-evm-v2/package.json
+++ b/packages/stg-evm-v2/package.json
@@ -50,7 +50,6 @@
     "clean": "rm -rf cache out artifacts dist deployed ts-src/typechain-types",
     "compile": "concurrently 'pnpm:compile:*'",
     "compile:forge": "forge build",
-    "compile:hardhat": "$npm_execpath hardhat compile",
     "compile:hardhat:evm": "$npm_execpath hardhat compile",
     "compile:hardhat:zksync": "$npm_execpath hardhat compile --network abstract-mainnet",
     "coverage:forge": "forge coverage --no-match-path ./test/invariant/StargateInvariantTest.t.sol --report lcov",


### PR DESCRIPTION
## Description

Removes duplicate `compile:hardhat` script from `packages/stg-evm-v2/package.json`. It was identical to `compile:hardhat:evm` (both run `hardhat compile`), so the parent `compile: concurrently 'pnpm:compile:*'` was spawning two hardhat processes that wrote to the same `artifacts/`, `cache/`, and `ts-src/typechain-types/`directories in parallel, causing intermittent CI failures