### PR TITLE
Bump Polygon bus gas limit

### DIFF
--- a/.changeset/polygon-bus-gas-limit.md
+++ b/.changeset/polygon-bus-gas-limit.md
@@ -1,0 +1,5 @@
+---
+"@stargatefinance/stg-definitions-v2": patch
+---
+
+Bump Polygon TokenMessaging bus gas limit

--- a/packages/stg-definitions-v2/src/constant.ts
+++ b/packages/stg-definitions-v2/src/constant.ts
@@ -3639,6 +3639,7 @@ export const NETWORKS: NetworksConfig = {
             },
             executor: EXECUTORS.LZ_LABS[EndpointId.POLYGON_V2_MAINNET],
             nativeDropAmount: parseEther('0.0324').toBigInt(),
+            busGasLimit: 65000n,
         },
         oneSigConfig: {
             oneSigAddress: '0x6ad59102caa47cfa76e7cf2ccc7d76557cc5e37d',

--- a/packages/stg-evm-v2/devtools/config/mainnet/01/hashes/hashes.json
+++ b/packages/stg-evm-v2/devtools/config/mainnet/01/hashes/hashes.json
@@ -61,7 +61,7 @@
   },
   {
     "name": "token-messaging.config.ts",
-    "hashedContent": "875084ef269b5b214a3bec95e81553096e67e2df0a7863fe6ed680e0d4ccdd0b"
+    "hashedContent": "c379badf070405d5c3bed4da94c96cb36556ac3aeb7f7dcf5255bf5b3054a3d7"
   },
   {
     "name": "treasurer.config.ts",

--- a/packages/stg-evm-v2/devtools/config/mainnet/01/json/token-messaging.config.json
+++ b/packages/stg-evm-v2/devtools/config/mainnet/01/json/token-messaging.config.json
@@ -983,7 +983,7 @@
           {
             "msgType": 2,
             "optionType": 1,
-            "gas": "38000"
+            "gas": "65000"
           }
         ],
         "sendConfig": {
@@ -3733,7 +3733,7 @@
           {
             "msgType": 2,
             "optionType": 1,
-            "gas": "38000"
+            "gas": "65000"
           }
         ],
         "sendConfig": {
@@ -6483,7 +6483,7 @@
           {
             "msgType": 2,
             "optionType": 1,
-            "gas": "38000"
+            "gas": "65000"
           }
         ],
         "sendConfig": {
@@ -12033,7 +12033,7 @@
           {
             "msgType": 2,
             "optionType": 1,
-            "gas": "38000"
+            "gas": "65000"
           }
         ],
         "sendConfig": {
@@ -14783,7 +14783,7 @@
           {
             "msgType": 2,
             "optionType": 1,
-            "gas": "38000"
+            "gas": "65000"
           }
         ],
         "sendConfig": {
@@ -17533,7 +17533,7 @@
           {
             "msgType": 2,
             "optionType": 1,
-            "gas": "38000"
+            "gas": "65000"
           }
         ],
         "sendConfig": {
@@ -20283,7 +20283,7 @@
           {
             "msgType": 2,
             "optionType": 1,
-            "gas": "38000"
+            "gas": "65000"
           }
         ],
         "sendConfig": {
@@ -23033,7 +23033,7 @@
           {
             "msgType": 2,
             "optionType": 1,
-            "gas": "38000"
+            "gas": "65000"
           }
         ],
         "sendConfig": {
@@ -25783,7 +25783,7 @@
           {
             "msgType": 2,
             "optionType": 1,
-            "gas": "38000"
+            "gas": "65000"
           }
         ],
         "sendConfig": {
@@ -28533,7 +28533,7 @@
           {
             "msgType": 2,
             "optionType": 1,
-            "gas": "38000"
+            "gas": "65000"
           }
         ],
         "sendConfig": {
@@ -31283,7 +31283,7 @@
           {
             "msgType": 2,
             "optionType": 1,
-            "gas": "38000"
+            "gas": "65000"
           }
         ],
         "sendConfig": {
@@ -34033,7 +34033,7 @@
           {
             "msgType": 2,
             "optionType": 1,
-            "gas": "38000"
+            "gas": "65000"
           }
         ],
         "sendConfig": {
@@ -36783,7 +36783,7 @@
           {
             "msgType": 2,
             "optionType": 1,
-            "gas": "38000"
+            "gas": "65000"
           }
         ],
         "sendConfig": {
@@ -39533,7 +39533,7 @@
           {
             "msgType": 2,
             "optionType": 1,
-            "gas": "38000"
+            "gas": "65000"
           }
         ],
         "sendConfig": {
@@ -42283,7 +42283,7 @@
           {
             "msgType": 2,
             "optionType": 1,
-            "gas": "38000"
+            "gas": "65000"
           }
         ],
         "sendConfig": {
@@ -45033,7 +45033,7 @@
           {
             "msgType": 2,
             "optionType": 1,
-            "gas": "38000"
+            "gas": "65000"
           }
         ],
         "sendConfig": {
@@ -47783,7 +47783,7 @@
           {
             "msgType": 2,
             "optionType": 1,
-            "gas": "38000"
+            "gas": "65000"
           }
         ],
         "sendConfig": {
@@ -50533,7 +50533,7 @@
           {
             "msgType": 2,
             "optionType": 1,
-            "gas": "38000"
+            "gas": "65000"
           }
         ],
         "sendConfig": {
@@ -53283,7 +53283,7 @@
           {
             "msgType": 2,
             "optionType": 1,
-            "gas": "38000"
+            "gas": "65000"
           }
         ],
         "sendConfig": {
@@ -56033,7 +56033,7 @@
           {
             "msgType": 2,
             "optionType": 1,
-            "gas": "38000"
+            "gas": "65000"
           }
         ],
         "sendConfig": {
@@ -58783,7 +58783,7 @@
           {
             "msgType": 2,
             "optionType": 1,
-            "gas": "38000"
+            "gas": "65000"
           }
         ],
         "sendConfig": {
@@ -61533,7 +61533,7 @@
           {
             "msgType": 2,
             "optionType": 1,
-            "gas": "38000"
+            "gas": "65000"
           }
         ],
         "sendConfig": {
@@ -64283,7 +64283,7 @@
           {
             "msgType": 2,
             "optionType": 1,
-            "gas": "38000"
+            "gas": "65000"
           }
         ],
         "sendConfig": {
@@ -67033,7 +67033,7 @@
           {
             "msgType": 2,
             "optionType": 1,
-            "gas": "38000"
+            "gas": "65000"
           }
         ],
         "sendConfig": {
@@ -69783,7 +69783,7 @@
           {
             "msgType": 2,
             "optionType": 1,
-            "gas": "38000"
+            "gas": "65000"
           }
         ],
         "sendConfig": {
@@ -72533,7 +72533,7 @@
           {
             "msgType": 2,
             "optionType": 1,
-            "gas": "38000"
+            "gas": "65000"
           }
         ],
         "sendConfig": {
@@ -75283,7 +75283,7 @@
           {
             "msgType": 2,
             "optionType": 1,
-            "gas": "38000"
+            "gas": "65000"
           }
         ],
         "sendConfig": {
@@ -78033,7 +78033,7 @@
           {
             "msgType": 2,
             "optionType": 1,
-            "gas": "38000"
+            "gas": "65000"
           }
         ],
         "sendConfig": {
@@ -80783,7 +80783,7 @@
           {
             "msgType": 2,
             "optionType": 1,
-            "gas": "38000"
+            "gas": "65000"
           }
         ],
         "sendConfig": {
@@ -83533,7 +83533,7 @@
           {
             "msgType": 2,
             "optionType": 1,
-            "gas": "38000"
+            "gas": "65000"
           }
         ],
         "sendConfig": {
@@ -86283,7 +86283,7 @@
           {
             "msgType": 2,
             "optionType": 1,
-            "gas": "38000"
+            "gas": "65000"
           }
         ],
         "sendConfig": {
@@ -89033,7 +89033,7 @@
           {
             "msgType": 2,
             "optionType": 1,
-            "gas": "38000"
+            "gas": "65000"
           }
         ],
         "sendConfig": {
@@ -91783,7 +91783,7 @@
           {
             "msgType": 2,
             "optionType": 1,
-            "gas": "38000"
+            "gas": "65000"
           }
         ],
         "sendConfig": {
@@ -94533,7 +94533,7 @@
           {
             "msgType": 2,
             "optionType": 1,
-            "gas": "38000"
+            "gas": "65000"
           }
         ],
         "sendConfig": {
@@ -97283,7 +97283,7 @@
           {
             "msgType": 2,
             "optionType": 1,
-            "gas": "38000"
+            "gas": "65000"
           }
         ],
         "sendConfig": {
@@ -100033,7 +100033,7 @@
           {
             "msgType": 2,
             "optionType": 1,
-            "gas": "38000"
+            "gas": "65000"
           }
         ],
         "sendConfig": {
@@ -102783,7 +102783,7 @@
           {
             "msgType": 2,
             "optionType": 1,
-            "gas": "38000"
+            "gas": "65000"
           }
         ],
         "sendConfig": {
@@ -105533,7 +105533,7 @@
           {
             "msgType": 2,
             "optionType": 1,
-            "gas": "38000"
+            "gas": "65000"
           }
         ],
         "sendConfig": {
@@ -108283,7 +108283,7 @@
           {
             "msgType": 2,
             "optionType": 1,
-            "gas": "38000"
+            "gas": "65000"
           }
         ],
         "sendConfig": {
@@ -111033,7 +111033,7 @@
           {
             "msgType": 2,
             "optionType": 1,
-            "gas": "38000"
+            "gas": "65000"
           }
         ],
         "sendConfig": {
@@ -113783,7 +113783,7 @@
           {
             "msgType": 2,
             "optionType": 1,
-            "gas": "38000"
+            "gas": "65000"
           }
         ],
         "sendConfig": {
@@ -116533,7 +116533,7 @@
           {
             "msgType": 2,
             "optionType": 1,
-            "gas": "38000"
+            "gas": "65000"
           }
         ],
         "sendConfig": {
@@ -119283,7 +119283,7 @@
           {
             "msgType": 2,
             "optionType": 1,
-            "gas": "38000"
+            "gas": "65000"
           }
         ],
         "sendConfig": {
@@ -122033,7 +122033,7 @@
           {
             "msgType": 2,
             "optionType": 1,
-            "gas": "38000"
+            "gas": "65000"
           }
         ],
         "sendConfig": {
@@ -124783,7 +124783,7 @@
           {
             "msgType": 2,
             "optionType": 1,
-            "gas": "38000"
+            "gas": "65000"
           }
         ],
         "sendConfig": {
@@ -127533,7 +127533,7 @@
           {
             "msgType": 2,
             "optionType": 1,
-            "gas": "38000"
+            "gas": "65000"
           }
         ],
         "sendConfig": {
@@ -130283,7 +130283,7 @@
           {
             "msgType": 2,
             "optionType": 1,
-            "gas": "38000"
+            "gas": "65000"
           }
         ],
         "sendConfig": {
@@ -133033,7 +133033,7 @@
           {
             "msgType": 2,
             "optionType": 1,
-            "gas": "38000"
+            "gas": "65000"
           }
         ],
         "sendConfig": {
@@ -135783,7 +135783,7 @@
           {
             "msgType": 2,
             "optionType": 1,
-            "gas": "38000"
+            "gas": "65000"
           }
         ],
         "sendConfig": {
@@ -138533,7 +138533,7 @@
           {
             "msgType": 2,
             "optionType": 1,
-            "gas": "38000"
+            "gas": "65000"
           }
         ],
         "sendConfig": {
@@ -141283,7 +141283,7 @@
           {
             "msgType": 2,
             "optionType": 1,
-            "gas": "38000"
+            "gas": "65000"
           }
         ],
         "sendConfig": {
@@ -144033,7 +144033,7 @@
           {
             "msgType": 2,
             "optionType": 1,
-            "gas": "38000"
+            "gas": "65000"
           }
         ],
         "sendConfig": {
@@ -146783,7 +146783,7 @@
           {
             "msgType": 2,
             "optionType": 1,
-            "gas": "38000"
+            "gas": "65000"
           }
         ],
         "sendConfig": {
@@ -149533,7 +149533,7 @@
           {
             "msgType": 2,
             "optionType": 1,
-            "gas": "38000"
+            "gas": "65000"
           }
         ],
         "sendConfig": {
@@ -152283,7 +152283,7 @@
           {
             "msgType": 2,
             "optionType": 1,
-            "gas": "38000"
+            "gas": "65000"
           }
         ],
         "sendConfig": {


### PR DESCRIPTION
Summary:
- Bump Polygon TokenMessaging bus gas limit to 65k
- Regenerate token messaging config snapshot and hash
- Add a patch changeset for stg-definitions-v2

Tests:
- prettier --check .changeset/polygon-bus-gas-limit.md packages/stg-definitions-v2/src/constant.ts packages/stg-evm-v2/devtools/config/mainnet/01/json/token-messaging.config.json packages/stg-evm-v2/devtools/config/mainnet/01/hashes/hashes.json
- Validated all 55 Polygon-destination BUS enforced options are 65000
- Validated token-messaging config hash matches generated JSON