### PR TITLE
🛑 [shutdown] Shimmer mainnet 

### DIFF
--- a/.changeset/yellow-countries-obey.md
+++ b/.changeset/yellow-countries-obey.md
@@ -1,0 +1,6 @@
+---
+"@stargatefinance/stg-definitions-v2": major
+"@stargatefinance/stg-evm-v2": major
+---
+
+Shutdown Shimmer mainnet

--- a/packages/stg-definitions-v2/src/constant.ts
+++ b/packages/stg-definitions-v2/src/constant.ts
@@ -1273,7 +1273,6 @@ export const OFT_WRAPPER: OftWrapperConfig = {
         [EndpointId.ROOTSTOCK_V2_MAINNET]: {},
         [EndpointId.SCROLL_V2_MAINNET]: {},
         [EndpointId.SEI_V2_MAINNET]: {},
-        [EndpointId.SHIMMER_V2_MAINNET]: {},
         [EndpointId.SOMNIA_V2_MAINNET]: {},
         [EndpointId.SONEIUM_V2_MAINNET]: {},
         [EndpointId.SONIC_V2_MAINNET]: {},
@@ -3669,16 +3668,6 @@ export const NETWORKS: NetworksConfig = {
         safeConfig: {
             safeAddress: '0xC02c4Ac2DBaA4eC11C306dDb0ABab5b421bd19fB',
             safeUrl: `${process.env.BASE_SAFE_URL_MAINNET}/scroll`,
-        },
-    },
-    [EndpointId.SHIMMER_V2_MAINNET]: {
-        oneSigConfig: {
-            oneSigAddress: '0xf7d8c13b546fbead84c30ec3e2df4a5d398d003b',
-            oneSigUrl: `${process.env.BASE_ONE_SIG_URL_MAINNET}/shimmer`,
-        },
-        safeConfig: {
-            safeAddress: '0x3ae59e4cffaad28e6588a269e2142e4a434d5a94',
-            safeUrl: `${process.env.BASE_SAFE_URL_MAINNET}/shimmer`,
         },
     },
     [EndpointId.SEI_V2_MAINNET]: {

--- a/packages/stg-evm-v2/devtools/config/mainnet/01/chainsConfig/shimmer-mainnet.yml
+++ b/packages/stg-evm-v2/devtools/config/mainnet/01/chainsConfig/shimmer-mainnet.yml
@@ -2,4 +2,4 @@ name: shimmer-mainnet
 eid: SHIMMER_V2_MAINNET
 token_messaging: false
 credit_messaging: false
-status: INACTIVE
+status: DEPRECATED

--- a/packages/stg-evm-v2/hardhat.config.ts
+++ b/packages/stg-evm-v2/hardhat.config.ts
@@ -650,14 +650,6 @@ const networks: NetworksUserConfig = {
         // Sei is giving us ProviderError: Out of gas: gas required exceeds allowance errors
         useFeeData: true,
     },
-    'shimmer-mainnet': {
-        eid: EndpointId.SHIMMER_V2_MAINNET,
-        url: process.env.RPC_URL_SHIMMER_MAINNET || 'https://json-rpc.evm.shimmer.network',
-        accounts: mainnetAccounts,
-        safeConfig: getSafeConfig(EndpointId.SHIMMER_V2_MAINNET),
-        oneSigConfig: getOneSigConfig(EndpointId.SHIMMER_V2_MAINNET),
-        timeout: DEFAULT_NETWORK_TIMEOUT,
-    },
     'somnia-mainnet': {
         eid: EndpointId.SOMNIA_V2_MAINNET,
         url: process.env.RPC_URL_SOMNIA_MAINNET || 'https://api.infra.mainnet.somnia.network/',


### PR DESCRIPTION
- Remove configuration
- Mark chain as Deprecated
- No Oapp was deployed so unwiring is no needed

ticket [OAPP-2993](https://linear.app/layerzerolabs/issue/OAPP-2993/shimmer-eid-30230-deprecate-chain-in-stargate-v2-repo)